### PR TITLE
fix(damiao): add settle delay after writing mode register to fix ensure_mode race

### DIFF
--- a/motor_vendors/damiao/src/motor.rs
+++ b/motor_vendors/damiao/src/motor.rs
@@ -18,6 +18,7 @@ const REGISTER_POLL_INTERVAL_MS: u64 = 2;
 const SET_ZERO_SETTLE_MS: u64 = 20;
 const ENSURE_MODE_VERIFY_ATTEMPTS: usize = 3;
 const ENSURE_MODE_VERIFY_RETRY_GAP_MS: u64 = 10;
+const WRITE_MODE_REGISTER_WAIT_MS: u64 = 20;
 
 const DAMIAO_MODELS: &[MotorModelSpec] = &[
     MotorModelSpec {
@@ -337,6 +338,10 @@ impl DamiaoMotor {
         }
 
         self.write_register_u32(10, desired)?;
+
+        std::thread::sleep(std::time::Duration::from_millis(
+            WRITE_MODE_REGISTER_WAIT_MS,
+        ));
 
         let mut last_error = None;
         for attempt in 0..ENSURE_MODE_VERIFY_ATTEMPTS {


### PR DESCRIPTION
## Problem

`ensure_mode` has a probabilistic failure: after writing register 10 (the mode register), the motor controller needs a short settling time before the new value can be reliably read back. Without this delay, the verification loop in `ensure_mode` would occasionally read the old value on the first attempt, causing spurious errors.

## Root Cause

The write → immediate read-back sequence in `ensure_mode` has a race between the host CAN write and the controller's internal register update. The controller does not guarantee the new value is reflected in the register before the next read frame arrives.

## Fix

Introduce a `WRITE_MODE_REGISTER_WAIT_MS` constant (20 ms) and insert a `std::thread::sleep` between the `write_register_u32` call and the verification loop. This gives the controller sufficient settling time so that the read-back consistently returns the updated value.

```rust
const WRITE_MODE_REGISTER_WAIT_MS: u64 = 20;

self.write_register_u32(10, desired)?;
std::thread::sleep(std::time::Duration::from_millis(WRITE_MODE_REGISTER_WAIT_MS));
// verification loop ...
```

## Testing

Verified on DM motor hardware over multiple repeated `ensure_mode` calls — no failures observed after the fix.