### PR TITLE
feat: add RobStride firmware version request and reply decoding

### DIFF
--- a/motor_vendors/robstride/src/lib.rs
+++ b/motor_vendors/robstride/src/lib.rs
@@ -7,10 +7,10 @@ pub use controller::RobstrideController;
 pub use motor::{model_limits, ControlMode, MotorFeedbackState, ParameterValue, RobstrideMotor};
 pub use protocol::{
     decode_fault_report, decode_ping_reply, decode_read_parameter_value, decode_status_frame,
-    encode_mit_command, encode_parameter_read, encode_parameter_write, encode_set_protocol,
-    ext_id_parts, protocol_name, validate_protocol_cmd, CommunicationType, FaultFlags, FaultReport,
-    PingReply, StatusFlags, StatusFrame, WarningFlags, PROTOCOL_CANOPEN, PROTOCOL_MIT,
-    PROTOCOL_PRIVATE,
+    decode_version_reply, encode_mit_command, encode_parameter_read, encode_parameter_write,
+    encode_set_protocol, encode_version_request, ext_id_parts, is_version_reply, protocol_name,
+    validate_protocol_cmd, CommunicationType, FaultFlags, FaultReport, PingReply, StatusFlags,
+    StatusFrame, VersionReply, WarningFlags, PROTOCOL_CANOPEN, PROTOCOL_MIT, PROTOCOL_PRIVATE,
 };
 pub use registers::{
     parameter_info, ParameterDataType, ParameterId, ParameterInfo, PARAMETER_TABLE,

--- a/motor_vendors/robstride/src/protocol.rs
+++ b/motor_vendors/robstride/src/protocol.rs
@@ -107,6 +107,12 @@ pub struct PingReply {
     pub payload: [u8; 8],
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct VersionReply {
+    pub device_id: u8,
+    pub version: [u8; 4],
+}
+
 pub fn build_ext_id(comm_type: u32, extra_data: u16, node_id: u8) -> u32 {
     (comm_type << 24) | (u32::from(extra_data) << 8) | u32::from(node_id)
 }
@@ -161,6 +167,39 @@ pub fn encode_mit_command(
         kd_u16 as u8,
     ];
     (torque_u16, data)
+}
+
+pub const VERSION_REQUEST_MARKER: u8 = 0xC4;
+pub const VERSION_REPLY_SIGNATURE: [u8; 3] = [0x00, 0xC4, 0x56];
+
+pub fn encode_version_request() -> [u8; 8] {
+    // Sent with comm type 4 (DISABLE); the marker byte is what makes the
+    // motor answer its firmware version instead of stopping.
+    let mut out = [0u8; 8];
+    out[1] = VERSION_REQUEST_MARKER;
+    out
+}
+
+pub fn is_version_reply(arbitration_id: u32, data: [u8; 8]) -> bool {
+    // Version replies arrive with comm type 2, same as status frames, so
+    // the payload signature is the only way to tell them apart. Passive
+    // listeners must check this before decode_status_frame, otherwise the
+    // version bytes decode as garbage telemetry.
+    let (comm_type, _, _) = ext_id_parts(arbitration_id);
+    comm_type == CommunicationType::OPERATION_STATUS && data[0..3] == VERSION_REPLY_SIGNATURE
+}
+
+pub fn decode_version_reply(arbitration_id: u32, data: [u8; 8]) -> Result<VersionReply> {
+    if !is_version_reply(arbitration_id, data) {
+        return Err(MotorError::Protocol(
+            "not a firmware-version reply".to_string(),
+        ));
+    }
+    let (_, extra_data, _) = ext_id_parts(arbitration_id);
+    Ok(VersionReply {
+        device_id: (extra_data & 0xFF) as u8,
+        version: [data[3], data[4], data[5], data[6]],
+    })
 }
 
 pub fn decode_ping_reply(arbitration_id: u32, data: [u8; 8]) -> Result<PingReply> {
@@ -309,6 +348,33 @@ mod fault_tests {
 mod tests {
     use super::*;
     use crate::motor::ParameterValue;
+
+    #[test]
+    fn version_request_encoding_sets_only_the_marker() {
+        assert_eq!(
+            encode_version_request(),
+            [0x00, 0xC4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        );
+    }
+
+    #[test]
+    fn version_reply_decode_matches_hardware_capture() {
+        // Captured from an RS03 (motor id 21, host 0xFD) running 0.3.1.41.
+        let arbitration_id = 0x020015FD;
+        let data = [0x00, 0xC4, 0x56, 0x00, 0x03, 0x01, 0x29, 0x07];
+        assert!(is_version_reply(arbitration_id, data));
+        let reply = decode_version_reply(arbitration_id, data).unwrap();
+        assert_eq!(reply.device_id, 21);
+        assert_eq!(reply.version, [0, 3, 1, 41]);
+    }
+
+    #[test]
+    fn version_reply_check_rejects_status_frames() {
+        let arbitration_id = build_ext_id(CommunicationType::OPERATION_STATUS, 21, 0xFD);
+        let data = [0x80, 0x00, 0x7F, 0xFF, 0x80, 0x12, 0x01, 0x2C];
+        assert!(!is_version_reply(arbitration_id, data));
+        assert!(decode_version_reply(arbitration_id, data).is_err());
+    }
 
     #[test]
     fn ext_id_build_and_parse_roundtrip() {


### PR DESCRIPTION
## Summary
Add support for the RobStride firmware version query (communication type 4 with the 0xC4 marker payload) to the robstride protocol module.

  ## Changes

  - `encode_version_request()`, `is_version_reply()`, `decode_version_reply()` and the `VersionReply` type in `motor_vendors/robstride/src/protocol.rs`, re-exported from the crate root.
  - Tests: encoding golden, a decode test using a reply captured from real hardware, and rejection of regular status frames.

  ## Validation

  - [x] `cargo check`
  - [x] `cargo test`
  - [x] Docs updated if needed

  ## Notes

  - Validated on RS00, RS02, RS03 and RS05 motors. Version fields follow the model line, e.g. an RS03 answers 0.3.1.41 and an RS02 answers 0.2.3.32.
  - Two sharp edges are noted as inline comments. The request shares communication type 4 with the disable command, only the marker byte differs, so it should only be sent when an accidental stop would be harmless. And the reply arrives as a communication type 2 frame, so passive listeners need to check `is_version_reply()` before `decode_status_frame()`, otherwise the version bytes decode as implausible telemetry (I first noticed this as a motor
  reporting 1050 °C).
  - The string parameters 0x1003–0x1006 (AppCodeVersion etc.) did not answer type 17 reads on my motors, which is why the dedicated query frame is the useful path.