### PR TITLE
fix: align rs-05 velocity and torque limits with the RS05 manual

### DIFF
--- a/motor_vendors/robstride/src/motor.rs
+++ b/motor_vendors/robstride/src/motor.rs
@@ -54,8 +54,8 @@ const ROBSTRIDE_MODELS: &[MotorModelSpec] = &[
         vendor: "robstride",
         model: "rs-05",
         pmax: 4.0 * std::f32::consts::PI,
-        vmax: 33.0,
-        tmax: 17.0,
+        vmax: 50.0,
+        tmax: 5.5,
     },
     MotorModelSpec {
         vendor: "robstride",


### PR DESCRIPTION
## Summary

- Fix the RobStride `rs-05` velocity and torque limits to match the manufacturer's manual (vmax 33 -> 50, tmax 17 -> 5.5).

## Changes

- `ROBSTRIDE_MODELS` entry for rs-05 in `motor_vendors/robstride/src/motor.rs`.

## Validation

- [x] `cargo check`
- [x] `cargo test`
- [x] Docs updated if needed

## Notes

-  The RS05 user manual documents the private-protocol frame scaling in both the type 1 (command) and type 2 (feedback) sections as `-50 to 50 rad/s` for velocity and `-5.5 to 5.5 Nm for torque`, and `5.5 Nm` is also the motor's listed peak load. The Kp (0 to 500) and Kd (0 to 5.0) ranges in the same table already match the values in this crate.
- Same kind of alignment as #9. With the old values, torque decoded from an RS05 comes out about 3x too high.
