### PR TITLE
feat/cyberbeast: add CyberBeast CAN protocol vendor crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ name = "motor_abi"
 version = "0.5.0"
 dependencies = [
  "motor_core",
+ "motor_vendor_cyberbeast",
  "motor_vendor_damiao",
  "motor_vendor_hexfellow",
  "motor_vendor_hightorque",
@@ -269,8 +270,10 @@ name = "motor_cli"
 version = "0.5.0"
 dependencies = [
  "motor_core",
+ "motor_vendor_cyberbeast",
  "motor_vendor_damiao",
  "motor_vendor_hexfellow",
+ "motor_vendor_hightorque",
  "motor_vendor_myactuator",
  "motor_vendor_robstride",
  "motor_vendor_robstride_cia402",
@@ -284,6 +287,13 @@ dependencies = [
  "cc",
  "libloading",
  "serialport",
+]
+
+[[package]]
+name = "motor_vendor_cyberbeast"
+version = "0.5.0"
+dependencies = [
+ "motor_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ version = "0.5.0"
 dependencies = [
  "futures-util",
  "motor_core",
+ "motor_vendor_cyberbeast",
  "motor_vendor_damiao",
  "motor_vendor_hexfellow",
  "motor_vendor_myactuator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "motor_vendors/hexfellow",
   "motor_vendors/hightorque",
   "motor_vendors/template",
+  "motor_vendors/cyberbeast",
   "motor_cli",
   "motor_abi",
   "integrations/ws_gateway",

--- a/integrations/ws_gateway/Cargo.toml
+++ b/integrations/ws_gateway/Cargo.toml
@@ -17,6 +17,7 @@ motor_vendor_damiao = { path = "../../motor_vendors/damiao" }
 motor_vendor_hexfellow = { path = "../../motor_vendors/hexfellow" }
 motor_vendor_myactuator = { path = "../../motor_vendors/myactuator" }
 motor_vendor_robstride = { path = "../../motor_vendors/robstride" }
+motor_vendor_cyberbeast = { path = "../../motor_vendors/cyberbeast" }
 motor_core = { path = "../../motor_core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/integrations/ws_gateway/src/commands/scan.rs
+++ b/integrations/ws_gateway/src/commands/scan.rs
@@ -8,6 +8,7 @@ use super::{
     as_u16, as_u64, parse_hex_or_dec, parse_id_list_csv, parse_transport_in_msg,
     parse_vendor_in_msg,
 };
+use crate::vendors::cyberbeast_ws::cmd_scan_cyberbeast;
 use crate::vendors::damiao_ws::cmd_scan_damiao;
 use crate::vendors::hightorque_ws::{send_hightorque_ext, wait_hightorque_status_for_motor};
 use crate::vendors::transport_ws::{
@@ -387,6 +388,7 @@ pub(crate) fn cmd_scan(v: &Value, base: &Target) -> Result<Value, String> {
         Vendor::Hexfellow => cmd_scan_hexfellow(v, base),
         Vendor::Myactuator => cmd_scan_myactuator(v, base),
         Vendor::Hightorque => cmd_scan_hightorque(v, base),
+        Vendor::CyberBeast => cmd_scan_cyberbeast(v, base),
     }
 }
 

--- a/integrations/ws_gateway/src/commands/vendor_ops.rs
+++ b/integrations/ws_gateway/src/commands/vendor_ops.rs
@@ -174,6 +174,9 @@ pub(crate) fn cmd_verify(v: &Value, base: &Target) -> Result<Value, String> {
                 "state": status.map(|s| json!({"pos_raw": s.pos_raw, "vel_raw": s.vel_raw, "tqe_raw": s.tqe_raw})),
             }))
         }
+        Vendor::CyberBeast => {
+            Err("verify is not supported for cyberbeast".to_string())
+        }
     }
 }
 
@@ -295,7 +298,10 @@ pub(crate) fn cmd_set_id(v: &Value, base: &Target) -> Result<Value, String> {
             }
             Ok(out)
         }
-        Vendor::Hexfellow | Vendor::Myactuator | Vendor::Hightorque => {
+        Vendor::Hexfellow
+        | Vendor::Myactuator
+        | Vendor::Hightorque
+        | Vendor::CyberBeast => {
             Err(format!("set_id is not supported for {}", vendor.as_str()))
         }
     }

--- a/integrations/ws_gateway/src/model.rs
+++ b/integrations/ws_gateway/src/model.rs
@@ -2,6 +2,7 @@ use motor_core::bus::CanBus;
 use motor_vendor_damiao::{DamiaoController, DamiaoMotor};
 use motor_vendor_hexfellow::{HexfellowController, HexfellowMotor};
 use motor_vendor_myactuator::{MyActuatorController, MyActuatorMotor};
+use motor_vendor_cyberbeast::{CyberBeastController, CyberBeastMotor};
 use motor_vendor_robstride::{RobstrideController, RobstrideMotor};
 use std::sync::Arc;
 
@@ -12,6 +13,7 @@ pub(crate) enum Vendor {
     Hightorque,
     Myactuator,
     Robstride,
+    CyberBeast,
 }
 
 impl Vendor {
@@ -22,6 +24,7 @@ impl Vendor {
             "hightorque" => Ok(Self::Hightorque),
             "myactuator" => Ok(Self::Myactuator),
             "robstride" => Ok(Self::Robstride),
+            "cyberbeast" => Ok(Self::CyberBeast),
             _ => Err(format!("unsupported vendor: {s}")),
         }
     }
@@ -32,6 +35,7 @@ impl Vendor {
             Self::Hexfellow => "hexfellow",
             Self::Hightorque => "hightorque",
             Self::Myactuator => "myactuator",
+            Self::CyberBeast => "cyberbeast",
             Self::Robstride => "robstride",
         }
     }
@@ -119,6 +123,7 @@ pub(crate) enum ControllerHandle {
     Hightorque(Box<dyn CanBus>),
     Myactuator(MyActuatorController),
     Robstride(RobstrideController),
+    CyberBeast(CyberBeastController),
 }
 
 pub(crate) enum MotorHandle {
@@ -127,4 +132,5 @@ pub(crate) enum MotorHandle {
     Hightorque(u16),
     Myactuator(Arc<MyActuatorMotor>),
     Robstride(Arc<RobstrideMotor>),
+    CyberBeast(Arc<CyberBeastMotor>),
 }

--- a/integrations/ws_gateway/src/router/handlers/connection.rs
+++ b/integrations/ws_gateway/src/router/handlers/connection.rs
@@ -128,6 +128,7 @@ fn handle_ping(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Vendor::Hexfellow => Ok(json!({"pong": true, "vendor":"hexfellow"})),
         Vendor::Myactuator => Ok(json!({"pong": true, "vendor":"myactuator"})),
         Vendor::Hightorque => Ok(json!({"pong": true, "vendor":"hightorque"})),
+        Vendor::CyberBeast => Ok(json!({"pong": true, "vendor":"cyberbeast"})),
     }
 }
 
@@ -232,6 +233,7 @@ fn handle_enable(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Some(MotorHandle::Hightorque(_)) => {}
         Some(MotorHandle::Myactuator(m)) => m.enable().map_err(|e| e.to_string())?,
         Some(MotorHandle::Robstride(m)) => m.enable().map_err(|e| e.to_string())?,
+        Some(MotorHandle::CyberBeast(m)) => m.enable().map_err(|e| e.to_string())?,
         None => return Err("motor not connected".to_string()),
     }
     ctx.active = None;
@@ -257,6 +259,7 @@ fn handle_disable(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Some(MotorHandle::Hightorque(_)) => {}
         Some(MotorHandle::Myactuator(m)) => m.disable().map_err(|e| e.to_string())?,
         Some(MotorHandle::Robstride(m)) => m.disable().map_err(|e| e.to_string())?,
+        Some(MotorHandle::CyberBeast(m)) => m.disable().map_err(|e| e.to_string())?,
         None => return Err("motor not connected".to_string()),
     }
     ctx.active = None;
@@ -292,6 +295,7 @@ fn handle_stop(ctx: &mut SessionCtx) -> Result<Value, String> {
             }
             MotorHandle::Myactuator(mm) => mm.stop_motor().map_err(|e| e.to_string())?,
             MotorHandle::Robstride(mm) => mm.set_velocity_target(0.0).map_err(|e| e.to_string())?,
+            MotorHandle::CyberBeast(mm) => mm.send_stop_motor().map_err(|e| e.to_string())?,
         }
     }
     Ok(json!({"stopped": true}))
@@ -502,7 +506,8 @@ fn handle_status(ctx: &mut SessionCtx) -> Result<Value, String> {
         (Some(ControllerHandle::Hexfellow(_)), Some(MotorHandle::Hexfellow(_)))
         | (Some(ControllerHandle::Damiao(_)), Some(MotorHandle::Damiao(_)))
         | (Some(ControllerHandle::Robstride(_)), Some(MotorHandle::Robstride(_)))
-        | (Some(ControllerHandle::Hightorque(_)), Some(MotorHandle::Hightorque(_))) => {}
+        | (Some(ControllerHandle::Hightorque(_)), Some(MotorHandle::Hightorque(_)))
+        | (Some(ControllerHandle::CyberBeast(_)), Some(MotorHandle::CyberBeast(_))) => {}
         _ => return Err("motor not connected".to_string()),
     }
     Ok(json!({"state": ctx.build_state_snapshot()?}))
@@ -522,6 +527,9 @@ fn handle_poll_feedback_once(ctx: &mut SessionCtx) -> Result<Value, String> {
             ControllerHandle::Myactuator(ctrl) => {
                 ctrl.poll_feedback_once().map_err(|e| e.to_string())?
             }
+            ControllerHandle::CyberBeast(ctrl) => {
+                ctrl.poll_feedback_once().map_err(|e| e.to_string())?
+            }
             ControllerHandle::Robstride(ctrl) => {
                 ctrl.poll_feedback_once().map_err(|e| e.to_string())?
             }
@@ -537,6 +545,7 @@ fn handle_shutdown(ctx: &mut SessionCtx) -> Result<Value, String> {
             ControllerHandle::Hexfellow(ctrl) => ctrl.shutdown().map_err(|e| e.to_string())?,
             ControllerHandle::Hightorque(bus) => bus.shutdown().map_err(|e| e.to_string())?,
             ControllerHandle::Myactuator(ctrl) => ctrl.shutdown().map_err(|e| e.to_string())?,
+            ControllerHandle::CyberBeast(ctrl) => ctrl.shutdown().map_err(|e| e.to_string())?,
             ControllerHandle::Robstride(ctrl) => ctrl.shutdown().map_err(|e| e.to_string())?,
         }
     }

--- a/integrations/ws_gateway/src/router/handlers/control.rs
+++ b/integrations/ws_gateway/src/router/handlers/control.rs
@@ -110,6 +110,9 @@ fn handle_mit(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Some(MotorHandle::Myactuator(_)) => {
             return Err("mit is not supported for myactuator".to_string());
         }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported for this operation".to_string());
+        }
         None => return Err("motor not connected".to_string()),
     }
     ctx.active = if as_bool(v, "continuous", false) {
@@ -202,6 +205,9 @@ fn handle_pos_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Some(MotorHandle::Myactuator(_)) => {
             Err("pos_vel is not supported for myactuator".to_string())
         }
+        Some(MotorHandle::CyberBeast(_)) => {
+            Err("cyberbeast not supported for this operation".to_string())
+        }
         None => Err("motor not connected".to_string()),
     }
 }
@@ -267,6 +273,9 @@ fn handle_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Some(MotorHandle::Hexfellow(_)) => {
             return Err("vel is not supported for hexfellow; use pos_vel or mit".to_string())
         }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported for this operation".to_string());
+        }
         None => return Err("motor not connected".to_string()),
     }
     ctx.active = if as_bool(v, "continuous", false) {
@@ -319,6 +328,9 @@ fn handle_force_pos(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         }
         Some(MotorHandle::Myactuator(_)) => {
             Err("force_pos is not supported for myactuator".to_string())
+        }
+        Some(MotorHandle::CyberBeast(_)) => {
+            Err("cyberbeast not supported for this operation".to_string())
         }
         None => Err("motor not connected".to_string()),
     }

--- a/integrations/ws_gateway/src/router/handlers/register.rs
+++ b/integrations/ws_gateway/src/router/handlers/register.rs
@@ -55,6 +55,9 @@ fn handle_clear_error(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> 
         Some(MotorHandle::Myactuator(_)) => {
             return Err("clear_error is not supported for myactuator".to_string())
         }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported".to_string());
+        }
         None => return Err("motor not connected".to_string()),
     }
     Ok(json!({"cleared": true}))
@@ -84,6 +87,9 @@ fn handle_set_zero_position(v: &Value, ctx: &mut SessionCtx) -> Result<Value, St
         }
         Some(MotorHandle::Hightorque(_)) => {
             return Err("set_zero_position is not supported for hightorque".to_string())
+        }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported".to_string());
         }
         None => return Err("motor not connected".to_string()),
     }
@@ -127,6 +133,9 @@ fn handle_ensure_mode(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> 
         }
         Some(MotorHandle::Hightorque(_)) => {
             return Err("ensure_mode is not supported for hightorque".to_string())
+        }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported".to_string());
         }
         None => return Err("motor not connected".to_string()),
     }
@@ -198,6 +207,9 @@ fn handle_set_active_report(v: &Value, ctx: &mut SessionCtx) -> Result<Value, St
         Some(MotorHandle::Myactuator(_)) => {
             return Err("set_active_report is not supported for myactuator".to_string())
         }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported".to_string());
+        }
         None => return Err("motor not connected".to_string()),
     }
     Ok(json!({"active_report": enabled}))
@@ -231,6 +243,9 @@ fn handle_store_parameters(v: &Value, ctx: &mut SessionCtx) -> Result<Value, Str
         Some(MotorHandle::Myactuator(_)) => {
             return Err("store_parameters is not supported for myactuator".to_string())
         }
+        Some(MotorHandle::CyberBeast(_)) => {
+            return Err("cyberbeast not supported".to_string());
+        }
         None => return Err("motor not connected".to_string()),
     }
     Ok(json!({"stored": true}))
@@ -259,6 +274,9 @@ fn handle_set_can_timeout_ms(v: &Value, ctx: &mut SessionCtx) -> Result<Value, S
         }
         Some(MotorHandle::Myactuator(_)) => {
             Err("set_can_timeout_ms is not supported for myactuator".to_string())
+        }
+        Some(MotorHandle::CyberBeast(_)) => {
+            Err("cyberbeast not supported".to_string())
         }
         None => Err("motor not connected".to_string()),
     }

--- a/integrations/ws_gateway/src/session/connect.rs
+++ b/integrations/ws_gateway/src/session/connect.rs
@@ -4,6 +4,7 @@ use motor_core::dm_device::DmDeviceType;
 use motor_vendor_damiao::DamiaoController;
 use motor_vendor_hexfellow::HexfellowController;
 use motor_vendor_myactuator::MyActuatorController;
+use motor_vendor_cyberbeast::CyberBeastController;
 use motor_vendor_robstride::RobstrideController;
 
 use super::{myactuator_feedback_default, SessionCtx};
@@ -125,6 +126,29 @@ impl SessionCtx {
                 self.controller = Some(ControllerHandle::Robstride(ctrl));
                 self.motor = Some(MotorHandle::Robstride(motor));
             }
+            Vendor::CyberBeast => {
+                let ctrl = match self.target.transport {
+                    Transport::Auto | Transport::SocketCan => {
+                        CyberBeastController::new_socketcan(&self.target.channel)
+                    }
+                    Transport::SocketCanFd => {
+                        CyberBeastController::new_socketcan(&self.target.channel)
+                    }
+                    _ => Err(motor_core::error::MotorError::InvalidArgument(
+                        "unsupported transport for cyberbeast".to_string(),
+                    )),
+                }
+                .map_err(|e| format!("open bus failed: {e}"))?;
+                let motor = ctrl
+                    .add_motor(
+                        self.target.motor_id,
+                        self.target.feedback_id,
+                        &self.target.model,
+                    )
+                    .map_err(|e| format!("add motor failed: {e}"))?;
+                self.controller = Some(ControllerHandle::CyberBeast(ctrl));
+                self.motor = Some(MotorHandle::CyberBeast(motor));
+            }
         }
         Ok(())
     }
@@ -159,6 +183,13 @@ impl SessionCtx {
                     let _ = bus.shutdown();
                 }
                 ControllerHandle::Myactuator(c) => {
+                    if shutdown {
+                        let _ = c.shutdown();
+                    } else {
+                        let _ = c.close_bus();
+                    }
+                }
+                ControllerHandle::CyberBeast(c) => {
                     if shutdown {
                         let _ = c.shutdown();
                     } else {

--- a/integrations/ws_gateway/src/session/runtime.rs
+++ b/integrations/ws_gateway/src/session/runtime.rs
@@ -149,6 +149,21 @@ impl SessionCtx {
                 }
                 None => Ok(()),
             },
+            Some(MotorHandle::CyberBeast(motor)) => match self.active.as_ref() {
+                Some(ActiveCommand::Mit { pos, vel, kp, kd, tau }) => motor
+                    .send_mit_command(*pos, *vel, *kp, *kd, *tau)
+                    .map_err(|e| e.to_string()),
+                Some(ActiveCommand::Vel { vel }) => motor
+                    .send_vel_control(vel.abs() * 60.0 / TWO_PI, 0.0)
+                    .map_err(|e| e.to_string()),
+                Some(ActiveCommand::PosVel { pos, vlim }) => motor
+                    .send_pos_control(pos * 360.0 / TWO_PI, vlim.abs() * 60.0 / TWO_PI, 0.0)
+                    .map_err(|e| e.to_string()),
+                Some(ActiveCommand::ForcePos { .. }) => motor
+                    .send_torque_control(0.0)
+                    .map_err(|e| e.to_string()),
+                None => Ok(()),
+            },
             None => Err("motor not connected".to_string()),
         }
     }

--- a/integrations/ws_gateway/src/vendors/cyberbeast_ws.rs
+++ b/integrations/ws_gateway/src/vendors/cyberbeast_ws.rs
@@ -1,0 +1,57 @@
+use crate::model::Target;
+use motor_vendor_cyberbeast::CyberBeastController;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+const SCAN_TIMEOUT_MS: u64 = 200;
+const SCAN_MAX_ID: u16 = 32;
+
+/// Scan for CyberBeast motors on the CAN bus.
+pub(crate) fn cmd_scan_cyberbeast(v: &Value, base: &Target) -> Result<Value, String> {
+    let start_id = v.get("start_id").and_then(|s| s.as_u64()).unwrap_or(1) as u16;
+    let end_id = v
+        .get("end_id")
+        .and_then(|s| s.as_u64())
+        .unwrap_or(SCAN_MAX_ID as u64) as u16;
+    let model = v
+        .get("model")
+        .and_then(|s| s.as_str())
+        .unwrap_or("odrive-default");
+
+    let ctrl = CyberBeastController::new_socketcan(&base.channel)
+        .map_err(|e| format!("open bus failed: {e}"))?;
+
+    let mut found: Vec<Value> = Vec::new();
+    for id in start_id..=end_id {
+        let motor = match ctrl.add_motor(id, id, model) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let _ = motor.send_start_motor();
+        let _ = motor.send_query_status();
+        std::thread::sleep(Duration::from_millis(SCAN_TIMEOUT_MS));
+        let _ = ctrl.poll_feedback_once();
+
+        if let Some(state) = motor.latest_state() {
+            found.push(json!({
+                "motor_id": id,
+                "pos": state.pos,
+                "vel": state.vel,
+                "current": state.current,
+                "error_code": state.error_code,
+                "mode_state": state.mode_state,
+                "motor_temp": state.motor_temp,
+                "mos_temp": state.mos_temp,
+                "heartbeat_life": state.heartbeat_life,
+            }));
+        }
+        let _ = motor.send_stop_motor();
+    }
+    let _ = ctrl.shutdown();
+
+    Ok(json!({
+        "vendor": "cyberbeast",
+        "found": found.len(),
+        "motors": found,
+    }))
+}

--- a/integrations/ws_gateway/src/vendors/mod.rs
+++ b/integrations/ws_gateway/src/vendors/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cyberbeast_ws;
 pub(crate) mod damiao_ws;
 pub(crate) mod hightorque_ws;
 pub(crate) mod robstride_ws;

--- a/motor_abi/Cargo.toml
+++ b/motor_abi/Cargo.toml
@@ -18,3 +18,4 @@ motor_vendor_hexfellow = { path = "../motor_vendors/hexfellow" }
 motor_vendor_hightorque = { path = "../motor_vendors/hightorque" }
 motor_vendor_myactuator = { path = "../motor_vendors/myactuator" }
 motor_vendor_robstride = { path = "../motor_vendors/robstride" }
+motor_vendor_cyberbeast = { path = "../motor_vendors/cyberbeast" }

--- a/motor_abi/include/motor_abi.h
+++ b/motor_abi/include/motor_abi.h
@@ -73,6 +73,7 @@ MotorHandle* motor_controller_add_hexfellow_motor(MotorController* controller, u
 MotorHandle* motor_controller_add_myactuator_motor(MotorController* controller, uint16_t motor_id, uint16_t feedback_id, const char* model);
 MotorHandle* motor_controller_add_robstride_motor(MotorController* controller, uint16_t motor_id, uint16_t feedback_id, const char* model);
 MotorHandle* motor_controller_add_hightorque_motor(MotorController* controller, uint16_t motor_id, uint16_t feedback_id, const char* model);
+MotorHandle* motor_controller_add_cyberbeast_motor(MotorController* controller, uint16_t motor_id, uint16_t feedback_id, const char* model);
 void motor_handle_free(MotorHandle* motor);
 
 int32_t motor_handle_enable(MotorHandle* motor);
@@ -120,6 +121,10 @@ int32_t motor_handle_damiao_get_param_f32(MotorHandle* motor, uint16_t param_id,
 int32_t motor_handle_damiao_get_param_u32(MotorHandle* motor, uint16_t param_id, uint32_t timeout_ms, uint32_t* out_value);
 int32_t motor_handle_damiao_write_param_f32(MotorHandle* motor, uint16_t param_id, float value);
 int32_t motor_handle_damiao_write_param_u32(MotorHandle* motor, uint16_t param_id, uint32_t value);
+
+// CyberBeast parameter access (SDO endpoint IDs)
+int32_t motor_handle_cyberbeast_get_param_f32(MotorHandle* motor, uint16_t param_id, uint32_t timeout_ms, float* out_value);
+int32_t motor_handle_cyberbeast_write_param_f32(MotorHandle* motor, uint16_t param_id, float value);
 
 #ifdef __cplusplus
 }

--- a/motor_abi/src/controller_add_motor_ffi.rs
+++ b/motor_abi/src/controller_add_motor_ffi.rs
@@ -69,3 +69,8 @@ add_motor_ffi!(
     ensure_hightorque_controller,
     Hightorque
 );
+add_motor_ffi!(
+    motor_controller_add_cyberbeast_motor,
+    ensure_cyberbeast_controller,
+    CyberBeast
+);

--- a/motor_abi/src/controller_lifecycle_ffi.rs
+++ b/motor_abi/src/controller_lifecycle_ffi.rs
@@ -7,6 +7,7 @@ macro_rules! dispatch_controller {
             ControllerInner::Hexfellow(ctrl) => ctrl.$method().map_err(|e| e.to_string()),
             ControllerInner::MyActuator(ctrl) => ctrl.$method().map_err(|e| e.to_string()),
             ControllerInner::Robstride(ctrl) => ctrl.$method().map_err(|e| e.to_string()),
+            ControllerInner::CyberBeast(ctrl) => ctrl.$method().map_err(|e| e.to_string()),
             ControllerInner::Hightorque(ctrl) => ctrl.$method().map_err(|e| e.to_string()),
             ControllerInner::Unbound(_) => Err(
                 "controller has no motor; add a motor before calling this operation".to_string(),

--- a/motor_abi/src/lib.rs
+++ b/motor_abi/src/lib.rs
@@ -8,6 +8,9 @@ use motor_vendor_hightorque::{HightorqueController, HightorqueMotor};
 use motor_vendor_myactuator::{
     ControlMode as MyActuatorControlMode, MyActuatorController, MyActuatorMotor,
 };
+use motor_vendor_cyberbeast::{
+    ControlMode as CyberBeastControlMode, CyberBeastController, CyberBeastMotor,
+};
 use motor_vendor_robstride::{
     ControlMode as RobstrideControlMode, ParameterValue, RobstrideController, RobstrideMotor,
 };
@@ -31,7 +34,7 @@ const ABI_CAPABILITIES: &str = r#"{
     "version": "__MOTORBRIDGE_VERSION__"
   },
   "transports": ["socketcan", "socketcanfd", "dm-serial", "dm-device"],
-  "vendors": ["damiao", "robstride", "myactuator", "hexfellow", "hightorque"],
+  "vendors": ["damiao", "robstride", "myactuator", "hexfellow", "hightorque", "cyberbeast"],
   "features": {
     "state_cache": true,
     "controller_lifecycle": ["shutdown", "close_bus", "poll_feedback_once", "enable_all", "disable_all"],
@@ -40,7 +43,8 @@ const ABI_CAPABILITIES: &str = r#"{
     "robstride": ["ping", "ping_host_id", "fault_report", "active_report", "device_id", "param_i8", "param_u8", "param_u16", "param_u32", "param_f32", "param_f32_host_id", "pos_vel_pp", "pos_vel_csp"],
     "myactuator": ["param_i8", "param_u8", "param_u16", "param_u32", "param_f32"],
     "hexfellow": ["socketcanfd", "mit", "pos_vel"],
-    "hightorque": ["mit", "vel", "param_i8", "param_u8", "param_u16", "param_u32", "param_f32"]
+    "hightorque": ["mit", "vel", "param_i8", "param_u8", "param_u16", "param_u32", "param_f32"],
+    "cyberbeast": ["mit", "pos-vel", "vel", "torque", "estop", "heartbeat", "param_f32"]
   }
 }"#;
 
@@ -82,6 +86,16 @@ fn to_robstride_mode(mode: u32) -> Result<RobstrideControlMode, &'static str> {
     }
 }
 
+fn to_cyberbeast_mode(mode: u32) -> Result<CyberBeastControlMode, &'static str> {
+    match mode {
+        1 => Ok(CyberBeastControlMode::Mit),
+        2 => Ok(CyberBeastControlMode::Position),
+        3 => Ok(CyberBeastControlMode::Velocity),
+        4 => Ok(CyberBeastControlMode::Torque),
+        _ => Err("CyberBeast mode must be 1(MIT) / 2(POSITION) / 3(VELOCITY) / 4(TORQUE)"),
+    }
+}
+
 fn to_myactuator_mode(mode: u32) -> Result<MyActuatorControlMode, &'static str> {
     match mode {
         1 => Ok(MyActuatorControlMode::Current),
@@ -93,6 +107,7 @@ fn to_myactuator_mode(mode: u32) -> Result<MyActuatorControlMode, &'static str> 
 
 enum ControllerInner {
     Unbound(String),
+    CyberBeast(CyberBeastController),
     Damiao(DamiaoController),
     Hexfellow(HexfellowController),
     MyActuator(MyActuatorController),
@@ -101,6 +116,7 @@ enum ControllerInner {
 }
 
 enum MotorHandleInner {
+    CyberBeast(Arc<CyberBeastMotor>),
     Damiao(Arc<DamiaoMotor>),
     Hexfellow(Arc<HexfellowMotor>),
     MyActuator(Arc<MyActuatorMotor>),
@@ -193,6 +209,7 @@ fn parse_cstr(ptr: *const c_char, name: &str) -> Result<String, String> {
 
 fn controller_vendor_name(inner: &ControllerInner) -> &'static str {
     match inner {
+        ControllerInner::CyberBeast(_) => "CyberBeast",
         ControllerInner::Damiao(_) => "Damiao",
         ControllerInner::Hexfellow(_) => "Hexfellow",
         ControllerInner::MyActuator(_) => "MyActuator",
@@ -249,6 +266,12 @@ ensure_controller!(
     Hightorque,
     HightorqueController,
     HightorqueController::new_socketcan
+);
+ensure_controller!(
+    ensure_cyberbeast_controller,
+    CyberBeast,
+    CyberBeastController,
+    CyberBeastController::new_socketcan
 );
 
 mod controller_add_motor_ffi;

--- a/motor_abi/src/motor_control_ffi.rs
+++ b/motor_abi/src/motor_control_ffi.rs
@@ -30,6 +30,10 @@ pub extern "C" fn motor_handle_ensure_mode(
                 m.ensure_control_mode(rs_mode, Duration::from_millis(timeout_ms as u64))
                     .map_err(|e| e.to_string())
             }
+            MotorHandleInner::CyberBeast(m) => {
+                let _ = to_cyberbeast_mode(mode).map_err(|e| e.to_string())?;
+                m.send_start_motor().map_err(|e| e.to_string())
+            }
             MotorHandleInner::Hightorque(m) => m
                 .ensure_control_mode(mode, Duration::from_millis(timeout_ms as u64))
                 .map_err(|e| e.to_string()),
@@ -78,6 +82,15 @@ pub extern "C" fn motor_handle_send_mit(
             }
             MotorHandleInner::Robstride(m) => m
                 .send_cmd_mit(
+                    target_position,
+                    target_velocity,
+                    stiffness,
+                    damping,
+                    feedforward_torque,
+                )
+                .map_err(|e| e.to_string()),
+            MotorHandleInner::CyberBeast(m) => m
+                .send_mit_command(
                     target_position,
                     target_velocity,
                     stiffness,
@@ -142,6 +155,13 @@ pub extern "C" fn motor_handle_send_pos_vel(
                         .map_err(|e| e.to_string())
                 })
             }
+            MotorHandleInner::CyberBeast(m) => m
+                .send_pos_control(
+                    target_position * (180.0 / PI),
+                    velocity_limit.abs() * (60.0 / (2.0 * PI)),
+                    0.0,
+                )
+                .map_err(|e| e.to_string()),
             MotorHandleInner::Hightorque(m) => m
                 .send_cmd_pos_vel(target_position, velocity_limit)
                 .map_err(|e| e.to_string()),
@@ -198,6 +218,12 @@ pub extern "C" fn motor_handle_send_vel(motor: *mut MotorHandle, target_velocity
             MotorHandleInner::Robstride(m) => m
                 .set_velocity_target(target_velocity)
                 .map_err(|e| e.to_string()),
+            MotorHandleInner::CyberBeast(m) => m
+                .send_vel_control(
+                    target_velocity.abs() * (60.0 / (2.0 * PI)),
+                    0.0,
+                )
+                .map_err(|e| e.to_string()),
             MotorHandleInner::Hightorque(m) => {
                 m.send_cmd_vel(target_velocity).map_err(|e| e.to_string())
             }
@@ -226,6 +252,9 @@ pub extern "C" fn motor_handle_send_force_pos(
             MotorHandleInner::Robstride(_) => {
                 Err("send_force_pos is not supported for RobStride".to_string())
             }
+            MotorHandleInner::CyberBeast(m) => m
+                .send_torque_control(torque_limit_ratio * m.mit_torque_limit)
+                .map_err(|e| e.to_string()),
             MotorHandleInner::Hightorque(m) => m
                 .send_cmd_force_pos(target_position, velocity_limit, torque_limit_ratio)
                 .map_err(|e| e.to_string()),
@@ -237,6 +266,7 @@ pub extern "C" fn motor_handle_send_force_pos(
 pub extern "C" fn motor_handle_store_parameters(motor: *mut MotorHandle) -> i32 {
     ffi_wrap_motor!(motor, |motor: &MotorHandleInner| {
         match motor {
+            MotorHandleInner::CyberBeast(m) => m.store_parameters().map_err(|e| e.to_string()),
             MotorHandleInner::Damiao(m) => m.store_parameters().map_err(|e| e.to_string()),
             MotorHandleInner::Hexfellow(_) => {
                 Err("store_parameters is not supported for Hexfellow".to_string())
@@ -266,6 +296,9 @@ pub extern "C" fn motor_handle_request_feedback(motor: *mut MotorHandle) -> i32 
             // robstride_ping() for connectivity checks, active report for streaming state,
             // or typed parameter reads for fresh position/velocity values.
             MotorHandleInner::Robstride(_) => Ok(()),
+            MotorHandleInner::CyberBeast(m) => {
+                m.send_query_status().map_err(|e| e.to_string())
+            }
             MotorHandleInner::Hightorque(m) => m
                 .request_motor_feedback(Duration::from_millis(500))
                 .map_err(|e| e.to_string()),

--- a/motor_abi/src/motor_lifecycle_ffi.rs
+++ b/motor_abi/src/motor_lifecycle_ffi.rs
@@ -1,4 +1,5 @@
 use super::*;
+use motor_core::device::MotorDevice;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn motor_handle_free(motor: *mut MotorHandle) {
@@ -18,6 +19,7 @@ pub extern "C" fn motor_handle_enable(motor: *mut MotorHandle) -> i32 {
                 .map_err(|e| e.to_string()),
             MotorHandleInner::MyActuator(m) => m.release_brake().map_err(|e| e.to_string()),
             MotorHandleInner::Robstride(m) => m.enable().map_err(|e| e.to_string()),
+            MotorHandleInner::CyberBeast(m) => m.enable().map_err(|e| e.to_string()),
             MotorHandleInner::Hightorque(m) => m.enable().map_err(|e| e.to_string()),
         }
     })
@@ -27,6 +29,7 @@ pub extern "C" fn motor_handle_enable(motor: *mut MotorHandle) -> i32 {
 pub extern "C" fn motor_handle_disable(motor: *mut MotorHandle) -> i32 {
     ffi_wrap_motor!(motor, |motor: &MotorHandleInner| {
         match motor {
+            MotorHandleInner::CyberBeast(m) => m.disable().map_err(|e| e.to_string()),
             MotorHandleInner::Damiao(m) => m.disable().map_err(|e| e.to_string()),
             MotorHandleInner::Hexfellow(m) => m
                 .disable_drive(Duration::from_millis(200))
@@ -42,6 +45,7 @@ pub extern "C" fn motor_handle_disable(motor: *mut MotorHandle) -> i32 {
 pub extern "C" fn motor_handle_clear_error(motor: *mut MotorHandle) -> i32 {
     ffi_wrap_motor!(motor, |motor: &MotorHandleInner| {
         match motor {
+            MotorHandleInner::CyberBeast(m) => m.send_clear_errors().map_err(|e| e.to_string()),
             MotorHandleInner::Damiao(m) => m.clear_error().map_err(|e| e.to_string()),
             MotorHandleInner::Hexfellow(_) => {
                 Err("clear_error is not supported for Hexfellow".to_string())
@@ -64,6 +68,7 @@ pub extern "C" fn motor_handle_set_zero_position(motor: *mut MotorHandle) -> i32
             MotorHandleInner::MyActuator(_) => {
                 Err("set_zero_position is not supported for MyActuator".to_string())
             }
+            MotorHandleInner::CyberBeast(m) => m.send_set_zero().map_err(|e| e.to_string()),
             MotorHandleInner::Robstride(m) => m.set_zero_position().map_err(|e| e.to_string()),
             MotorHandleInner::Hightorque(m) => m.set_zero_position().map_err(|e| e.to_string()),
         }

--- a/motor_abi/src/motor_register_ffi.rs
+++ b/motor_abi/src/motor_register_ffi.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+fn cyberbeast_not_supported() -> Result<(), String> {
+    Err("register operations are not supported for CyberBeast; use param_f32 endpoints".to_string())
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn motor_handle_set_can_timeout_ms(motor: *mut MotorHandle, timeout_ms: u32) -> i32 {
     if motor.is_null() {
@@ -21,6 +25,7 @@ pub extern "C" fn motor_handle_set_can_timeout_ms(motor: *mut MotorHandle, timeo
         MotorHandleInner::Robstride(m) => m
             .write_parameter(0x7028, ParameterValue::U32(timeout_ms))
             .map_err(|e| e.to_string()),
+        MotorHandleInner::CyberBeast(_) => cyberbeast_not_supported(),
         MotorHandleInner::Hightorque(_) => {
             Err("set_can_timeout_ms is not supported for HighTorque".to_string())
         }
@@ -128,7 +133,7 @@ pub extern "C" fn motor_handle_robstride_ping(
         MotorHandleInner::Damiao(_)
         | MotorHandleInner::Hexfellow(_)
         | MotorHandleInner::MyActuator(_)
-        | MotorHandleInner::Hightorque(_) => {
+        | MotorHandleInner::CyberBeast(_) | MotorHandleInner::Hightorque(_) => {
             Err("robstride_ping requires a RobStride motor".to_string())
         }
     };
@@ -167,7 +172,7 @@ pub extern "C" fn motor_handle_robstride_ping_host_id(
         MotorHandleInner::Damiao(_)
         | MotorHandleInner::Hexfellow(_)
         | MotorHandleInner::MyActuator(_)
-        | MotorHandleInner::Hightorque(_) => {
+        | MotorHandleInner::CyberBeast(_) | MotorHandleInner::Hightorque(_) => {
             Err("robstride_ping_host_id requires a RobStride motor".to_string())
         }
     };
@@ -214,7 +219,7 @@ pub extern "C" fn motor_handle_robstride_get_param_f32_host_id(
         MotorHandleInner::Damiao(_)
         | MotorHandleInner::Hexfellow(_)
         | MotorHandleInner::MyActuator(_)
-        | MotorHandleInner::Hightorque(_) => {
+        | MotorHandleInner::CyberBeast(_) | MotorHandleInner::Hightorque(_) => {
             Err("robstride_get_param_f32_host_id requires a RobStride motor".to_string())
         }
     };
@@ -244,7 +249,7 @@ pub extern "C" fn motor_handle_robstride_get_fault_report(
         MotorHandleInner::Damiao(_)
         | MotorHandleInner::Hexfellow(_)
         | MotorHandleInner::MyActuator(_)
-        | MotorHandleInner::Hightorque(_) => {
+        | MotorHandleInner::CyberBeast(_) | MotorHandleInner::Hightorque(_) => {
             set_last_error("robstride_get_fault_report requires a RobStride motor");
             -1
         }
@@ -266,7 +271,7 @@ pub extern "C" fn motor_handle_robstride_set_device_id(
         MotorHandleInner::Damiao(_)
         | MotorHandleInner::Hexfellow(_)
         | MotorHandleInner::MyActuator(_)
-        | MotorHandleInner::Hightorque(_) => {
+        | MotorHandleInner::CyberBeast(_) | MotorHandleInner::Hightorque(_) => {
             Err("robstride_set_device_id requires a RobStride motor".to_string())
         }
     };
@@ -290,7 +295,7 @@ pub extern "C" fn motor_handle_robstride_set_active_report(
         MotorHandleInner::Damiao(_)
         | MotorHandleInner::Hexfellow(_)
         | MotorHandleInner::MyActuator(_)
-        | MotorHandleInner::Hightorque(_) => {
+        | MotorHandleInner::CyberBeast(_) | MotorHandleInner::Hightorque(_) => {
             Err("robstride_set_active_report requires a RobStride motor".to_string())
         }
     };

--- a/motor_abi/src/param_ffi/cyberbeast/get_ffi.rs
+++ b/motor_abi/src/param_ffi/cyberbeast/get_ffi.rs
@@ -1,0 +1,15 @@
+use super::super::common::ffi_get;
+use crate::vendor_params::cyberbeast;
+use crate::MotorHandle;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn motor_handle_cyberbeast_get_param_f32(
+    motor: *mut MotorHandle,
+    param_id: u16,
+    timeout_ms: u32,
+    out_value: *mut f32,
+) -> i32 {
+    ffi_get(motor, out_value, |m| {
+        cyberbeast::get_f32(m, param_id, timeout_ms)
+    })
+}

--- a/motor_abi/src/param_ffi/cyberbeast/mod.rs
+++ b/motor_abi/src/param_ffi/cyberbeast/mod.rs
@@ -1,0 +1,2 @@
+mod get_ffi;
+mod write_ffi;

--- a/motor_abi/src/param_ffi/cyberbeast/write_ffi.rs
+++ b/motor_abi/src/param_ffi/cyberbeast/write_ffi.rs
@@ -1,0 +1,12 @@
+use super::super::common::ffi_run;
+use crate::vendor_params::cyberbeast;
+use crate::MotorHandle;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn motor_handle_cyberbeast_write_param_f32(
+    motor: *mut MotorHandle,
+    param_id: u16,
+    value: f32,
+) -> i32 {
+    ffi_run(motor, |m| cyberbeast::write_f32(m, param_id, value))
+}

--- a/motor_abi/src/param_ffi/mod.rs
+++ b/motor_abi/src/param_ffi/mod.rs
@@ -118,6 +118,7 @@ macro_rules! define_param_write_ffis_5 {
 }
 
 mod common;
+mod cyberbeast;
 mod damiao;
 mod hexfellow;
 mod hightorque;

--- a/motor_abi/src/state_ffi.rs
+++ b/motor_abi/src/state_ffi.rs
@@ -101,6 +101,23 @@ pub extern "C" fn motor_handle_get_state(
                 *out = MotorState::default();
             }
         }
+        MotorHandleInner::CyberBeast(m) => {
+            if let Some(state) = m.latest_state() {
+                *out = MotorState {
+                    has_value: 1,
+                    can_id: state.can_id_parts.source,
+                    arbitration_id: state.arbitration_id,
+                    status_code: state.error_code,
+                    pos: state.pos,
+                    vel: state.vel,
+                    torq: state.current,
+                    t_mos: state.mos_temp,
+                    t_rotor: state.motor_temp,
+                };
+            } else {
+                *out = MotorState::default();
+            }
+        }
         MotorHandleInner::Hightorque(m) => {
             if let Some(state) = m.latest_state() {
                 *out = MotorState {

--- a/motor_abi/src/vendor_params/cyberbeast.rs
+++ b/motor_abi/src/vendor_params/cyberbeast.rs
@@ -1,0 +1,34 @@
+use crate::MotorHandleInner;
+use motor_vendor_cyberbeast::CyberBeastMotor;
+use std::sync::Arc;
+use std::time::Duration;
+
+const DEFAULT_PARAM_TIMEOUT_MS: u64 = 200;
+
+/// Get a float32 parameter value from a CyberBeast motor by SDO endpoint ID.
+pub(crate) fn get_f32(
+    motor: &MotorHandleInner,
+    param_id: u16,
+    timeout_ms: u32,
+) -> Result<f32, String> {
+    let m: &Arc<CyberBeastMotor> = match motor {
+        MotorHandleInner::CyberBeast(m) => m,
+        _ => return Err("motor is not a CyberBeast motor".to_string()),
+    };
+    let timeout = Duration::from_millis(u64::from(timeout_ms).max(DEFAULT_PARAM_TIMEOUT_MS));
+    m.send_param_read(param_id).map_err(|e| e.to_string())?;
+    m.get_param_f32(param_id, timeout).map_err(|e| e.to_string())
+}
+
+/// Write a float32 parameter value to a CyberBeast motor by SDO endpoint ID.
+pub(crate) fn write_f32(
+    motor: &MotorHandleInner,
+    param_id: u16,
+    value: f32,
+) -> Result<(), String> {
+    let m: &Arc<CyberBeastMotor> = match motor {
+        MotorHandleInner::CyberBeast(m) => m,
+        _ => return Err("motor is not a CyberBeast motor".to_string()),
+    };
+    m.set_param_f32(param_id, value).map_err(|e| e.to_string())
+}

--- a/motor_abi/src/vendor_params/mod.rs
+++ b/motor_abi/src/vendor_params/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cyberbeast;
 pub(crate) mod damiao;
 pub(crate) mod hexfellow;
 pub(crate) mod hightorque;

--- a/motor_cli/Cargo.toml
+++ b/motor_cli/Cargo.toml
@@ -20,3 +20,5 @@ motor_vendor_robstride_cia402 = { path = "../motor_vendors/robstride_cia402" }
 motor_vendor_robstride_mit = { path = "../motor_vendors/robstride_mit" }
 motor_vendor_myactuator = { path = "../motor_vendors/myactuator" }
 motor_vendor_hexfellow = { path = "../motor_vendors/hexfellow" }
+motor_vendor_hightorque = { path = "../motor_vendors/hightorque" }
+motor_vendor_cyberbeast = { path = "../motor_vendors/cyberbeast" }

--- a/motor_cli/src/cyberbeast_cli.rs
+++ b/motor_cli/src/cyberbeast_cli.rs
@@ -1,0 +1,167 @@
+use crate::args::{get_f32, get_str, get_u16_hex_or_dec, get_u64};
+use motor_vendor_cyberbeast::CyberBeastController;
+use std::collections::HashMap;
+use std::time::Duration;
+
+const SCAN_TIMEOUT_MS: u64 = 200;
+
+pub fn run_cyberbeast(
+    args: &HashMap<String, String>,
+    channel: &str,
+    model: &str,
+    motor_id: u16,
+    _feedback_id: u16,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mode = get_str(args, "mode", "status");
+    let ctrl = CyberBeastController::new_socketcan(channel)?;
+
+    match mode.as_str() {
+        "scan" => {
+            let start_id = get_u16_hex_or_dec(args, "start-id", 1)?;
+            let end_id = get_u16_hex_or_dec(args, "end-id", 32)?;
+            println!("scanning CyberBeast motors on {channel} (IDs {start_id}..{end_id})...");
+
+            for id in start_id..=end_id {
+                let motor = match ctrl.add_motor(id, id, model) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                let _ = motor.send_start_motor();
+                let _ = motor.send_query_status();
+                std::thread::sleep(Duration::from_millis(SCAN_TIMEOUT_MS));
+                let _ = ctrl.poll_feedback_once();
+
+                if let Some(state) = motor.latest_state() {
+                    println!(
+                        "  [found] id=0x{id:02X} pos={:.3} vel={:.3} current={:.3} err=0x{:X} mode={} motor_temp={:.1}°C mos_temp={:.1}°C",
+                        state.pos, state.vel, state.current, state.error_code, state.mode_state, state.motor_temp, state.mos_temp
+                    );
+                }
+                let _ = motor.send_stop_motor();
+            }
+            ctrl.shutdown()?;
+        }
+
+        "status" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            let _ = motor.send_start_motor();
+            let _ = motor.send_query_status();
+            std::thread::sleep(Duration::from_millis(SCAN_TIMEOUT_MS));
+            let _ = ctrl.poll_feedback_once();
+
+            if let Some(state) = motor.latest_state() {
+                println!("status for motor 0x{motor_id:02X}:");
+                println!("  pos={:.4} rad, vel={:.4} rad/s", state.pos, state.vel);
+                println!("  current={:.3} A, error=0x{:X}, mode={}", state.current, state.error_code, state.mode_state);
+                println!("  motor_temp={:.1}°C, mos_temp={:.1}°C", state.motor_temp, state.mos_temp);
+                if let Some(life) = state.heartbeat_life {
+                    println!("  heartbeat_life={}", life);
+                }
+            } else {
+                println!("no response from motor 0x{motor_id:02X}");
+            }
+            let _ = motor.send_stop_motor();
+            ctrl.shutdown()?;
+        }
+
+        "mit" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            println!("starting MIT control for motor 0x{motor_id:02X} (Ctrl+C to stop)...");
+            let _ = motor.send_start_motor();
+            let kp = get_f32(args, "kp", 100.0)?;
+            let kd = get_f32(args, "kd", 10.0)?;
+            let loop_ms = get_u64(args, "loop-ms", 5)?;
+
+            loop {
+                let pos = get_f32(args, "pos", 0.0)?;
+                let vel = get_f32(args, "vel", 0.0)?;
+                let torque = get_f32(args, "torque", 0.0)?;
+                motor.send_mit_command(pos, vel, kp, kd, torque)?;
+                let _ = ctrl.poll_feedback_once();
+                if let Some(state) = motor.latest_state() {
+                    print!("\rpos={:.4} vel={:.4} cur={:.3} err=0x{:X} mode={} temp={:.1}°C",
+                        state.pos, state.vel, state.current, state.error_code, state.mode_state, state.motor_temp);
+                }
+                std::thread::sleep(Duration::from_millis(loop_ms));
+            }
+        }
+
+        "pos" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            println!("starting POS control for motor 0x{motor_id:02X} (Ctrl+C to stop)...");
+            let _ = motor.send_start_motor();
+            let loop_ms = get_u64(args, "loop-ms", 10)?;
+
+            loop {
+                let pos = get_f32(args, "pos", 0.0)?;
+                let vel_limit = get_f32(args, "vel-limit", 100.0)?;
+                motor.send_pos_control(pos, vel_limit, 0.0)?;
+                let _ = ctrl.poll_feedback_once();
+                if let Some(state) = motor.latest_state() {
+                    print!("\rpos={:.4} vel={:.4} err=0x{:X}",
+                        state.pos, state.vel, state.error_code);
+                }
+                std::thread::sleep(Duration::from_millis(loop_ms));
+            }
+        }
+
+        "vel" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            println!("starting VEL control for motor 0x{motor_id:02X} (Ctrl+C to stop)...");
+            let _ = motor.send_start_motor();
+            let loop_ms = get_u64(args, "loop-ms", 10)?;
+
+            loop {
+                let vel_rpm = get_f32(args, "vel", 0.0)?;
+                motor.send_vel_control(vel_rpm, 0.0)?;
+                let _ = ctrl.poll_feedback_once();
+                if let Some(state) = motor.latest_state() {
+                    print!("\rvel={:.4} cur={:.3} err=0x{:X}",
+                        state.vel, state.current, state.error_code);
+                }
+                std::thread::sleep(Duration::from_millis(loop_ms));
+            }
+        }
+
+        "torque" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            println!("starting TORQUE control for motor 0x{motor_id:02X} (Ctrl+C to stop)...");
+            let _ = motor.send_start_motor();
+            let loop_ms = get_u64(args, "loop-ms", 5)?;
+
+            loop {
+                let torque_nm = get_f32(args, "torque", 0.0)?;
+                motor.send_torque_control(torque_nm)?;
+                let _ = ctrl.poll_feedback_once();
+                if let Some(state) = motor.latest_state() {
+                    print!("\rtorque_target={:.4} cur={:.3} err=0x{:X}",
+                        torque_nm, state.current, state.error_code);
+                }
+                std::thread::sleep(Duration::from_millis(loop_ms));
+            }
+        }
+
+        "enable" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            motor.send_start_motor()?;
+            println!("enabled motor 0x{motor_id:02X}");
+            ctrl.shutdown()?;
+        }
+
+        "disable" => {
+            let motor = ctrl.add_motor(motor_id, motor_id, model)?;
+            motor.send_stop_motor()?;
+            println!("disabled motor 0x{motor_id:02X}");
+            ctrl.shutdown()?;
+        }
+
+        other => {
+            eprintln!(
+                "unknown mode: {other}. Supported: scan, status, mit, pos, vel, torque, enable, disable"
+            );
+            ctrl.shutdown()?;
+        }
+    }
+
+    Ok(())
+}

--- a/motor_cli/src/main.rs
+++ b/motor_cli/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod cyberbeast_cli;
 mod damiao_cli;
 mod hexfellow_cli;
 mod hightorque_cli;
@@ -8,6 +9,7 @@ mod robstride_cli;
 mod robstride_mit_cli;
 
 use args::{get_str, get_u16_hex_or_dec, print_help};
+use cyberbeast_cli::run_cyberbeast;
 use damiao_cli::run_damiao;
 use hexfellow_cli::run_hexfellow;
 use hightorque_cli::run_hightorque;
@@ -40,6 +42,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "X8"
         } else if vendor == "hexfellow" {
             "hexfellow"
+        } else if vendor == "cyberbeast" {
+            "odrive-default"
         } else {
             "4340"
         };
@@ -50,6 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "robstride_cia402" | "hexfellow" => 0x0000,
         "hightorque" => 0x0001,
         "myactuator" => 0x0241,
+        "cyberbeast" => 0x0000,
         _ => 0x0011,
     };
     let feedback_id = get_u16_hex_or_dec(&args, "feedback-id", feedback_default)?;
@@ -60,6 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "robstride" => "ping",
             "robstride_mit" | "robstride_cia402" | "myactuator" | "hexfellow" => "status",
             "hightorque" => "read",
+            "cyberbeast" => "status",
             "all" => "scan",
             _ => "mit",
         },
@@ -181,6 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "hightorque" => run_hightorque(&args, &channel, motor_id),
         "myactuator" => run_myactuator(&args, &channel, &model, motor_id, feedback_id),
         "hexfellow" => run_hexfellow(&args, &channel, &model, motor_id, feedback_id),
+        "cyberbeast" => run_cyberbeast(&args, &channel, &model, motor_id, feedback_id),
         _ => Err(format!("unknown vendor: {vendor}").into()),
     }
 }

--- a/motor_vendors/cyberbeast/Cargo.toml
+++ b/motor_vendors/cyberbeast/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "motor_vendor_cyberbeast"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+name = "motor_vendor_cyberbeast"
+path = "src/lib.rs"
+
+[dependencies]
+motor_core = { path = "../../motor_core" }
+
+[dev-dependencies]
+motor_core = { path = "../../motor_core", features = ["test-support"] }

--- a/motor_vendors/cyberbeast/src/controller.rs
+++ b/motor_vendors/cyberbeast/src/controller.rs
@@ -1,0 +1,68 @@
+use crate::motor::CyberBeastMotor;
+use motor_core::bus::{open_can_bus, CanBus};
+use motor_core::error::Result;
+use motor_core::vendor_controller::VendorController;
+use std::sync::Arc;
+
+pub struct CyberBeastController {
+    controller: VendorController<CyberBeastMotor>,
+}
+
+impl CyberBeastController {
+    pub fn new(bus: Arc<dyn CanBus>) -> Self {
+        Self {
+            controller: VendorController::new(bus),
+        }
+    }
+
+    pub fn new_socketcan(channel: &str) -> Result<Self> {
+        Ok(Self::new(open_can_bus(channel)?))
+    }
+
+    pub fn add_motor(
+        &self,
+        motor_id: u16,
+        feedback_id: u16,
+        model: &str,
+    ) -> Result<Arc<CyberBeastMotor>> {
+        self.controller.add_motor_with(motor_id, |bus| {
+            CyberBeastMotor::new(motor_id, feedback_id, model, bus)
+        })
+    }
+
+    pub fn add_motor_with_master(
+        &self,
+        motor_id: u16,
+        feedback_id: u16,
+        model: &str,
+        master_id: u8,
+    ) -> Result<Arc<CyberBeastMotor>> {
+        self.controller.add_motor_with(motor_id, |bus| {
+            Ok(CyberBeastMotor::new(motor_id, feedback_id, model, bus)?.with_master_id(master_id))
+        })
+    }
+
+    pub fn get_motor(&self, motor_id: u16) -> Result<Arc<CyberBeastMotor>> {
+        self.controller.get_motor(motor_id)
+    }
+
+    pub fn poll_feedback_once(&self) -> Result<()> {
+        self.controller.poll_feedback_once()
+    }
+
+    pub fn enable_all(&self) -> Result<()> {
+        self.controller.enable_all()
+    }
+
+    pub fn disable_all(&self) -> Result<()> {
+        self.controller.disable_all()
+    }
+
+    pub fn shutdown(&self) -> Result<()> {
+        self.controller.shutdown()
+    }
+
+    pub fn close_bus(&self) -> Result<()> {
+        self.controller.close_bus()
+    }
+}

--- a/motor_vendors/cyberbeast/src/lib.rs
+++ b/motor_vendors/cyberbeast/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod controller;
+pub mod motor;
+pub mod protocol;
+pub mod registers;
+
+pub use controller::CyberBeastController;
+pub use motor::{model_limits, ControlMode, CyberBeastMotor, CyberBeastMotorState};
+pub use protocol::{
+    big_endian_bytes_to_f32, can_id_parts, f32_to_big_endian_bytes, make_can_id,
+    unpack_mit_response, CyberBeastCanId, ErrorCode, ModeState, MsgType, Priority, ADDR_BROADCAST,
+    MSGTYPE_BROADCAST_THRESHOLD, PRIORITY_MASK, SEQ_MASK,
+    encode_param_read, encode_param_write, decode_param_read_response, is_param_write_ack,
+    encode_config_save, MitCommandParams, MitResponse, HeartbeatFrame, decode_heartbeat,
+};
+pub use registers::{RegisterInfo, REGISTER_TABLE};

--- a/motor_vendors/cyberbeast/src/motor.rs
+++ b/motor_vendors/cyberbeast/src/motor.rs
@@ -1,0 +1,997 @@
+use crate::protocol::{
+    self, can_id_parts, encode_clear_errors, encode_config_save, encode_current_control,
+    encode_param_read, encode_param_write, encode_pos_control, encode_set_zero,
+    encode_torque_control, encode_vel_control, make_can_id, pack_mit_command, seq_next,
+    unpack_mit_response, CyberBeastCanId, MitCommandParams, MsgType, Priority, DEFAULT_MASTER_ID,
+    MAX_BROADCAST_DEVICES,
+};
+use motor_core::bus::{CanBus, CanFrame};
+use motor_core::device::MotorDevice;
+use motor_core::error::{MotorError, Result};
+use motor_core::model::{ModelCatalog, MotorModelSpec, PvTLimits, StaticModelCatalog};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+// ============================================================================
+// Model catalog
+// ============================================================================
+
+/// Common ODrive-based motor configurations for CyberBeast protocol.
+///
+/// These are typical setups. Users may need to adjust P/V/T limits for
+/// their specific mechanical configuration (gear ratio, etc.).
+const CYBERBEAST_MODELS: &[MotorModelSpec] = &[
+    MotorModelSpec {
+        vendor: "cyberbeast",
+        model: "odrive-default",
+        pmax: 4.0 * std::f32::consts::PI, // ±4π rad
+        vmax: 100.0,                      // ±100 rad/s (output)
+        tmax: 10.0,                       // ±10 Nm
+    },
+    MotorModelSpec {
+        vendor: "cyberbeast",
+        model: "odrive-pro",
+        pmax: 4.0 * std::f32::consts::PI,
+        vmax: 150.0,
+        tmax: 20.0,
+    },
+    MotorModelSpec {
+        vendor: "cyberbeast",
+        model: "odrive-high-torque",
+        pmax: 4.0 * std::f32::consts::PI,
+        vmax: 60.0,
+        tmax: 50.0,
+    },
+    MotorModelSpec {
+        vendor: "cyberbeast",
+        model: "odrive-high-speed",
+        pmax: 4.0 * std::f32::consts::PI,
+        vmax: 300.0,
+        tmax: 5.0,
+    },
+];
+
+const CYBERBEAST_CATALOG: StaticModelCatalog = StaticModelCatalog {
+    vendor_name: "cyberbeast",
+    models: CYBERBEAST_MODELS,
+};
+
+pub fn model_limits(model: &str) -> Option<(f32, f32, f32)> {
+    CYBERBEAST_CATALOG
+        .get(model)
+        .map(|spec| (spec.pmax, spec.vmax, spec.tmax))
+}
+
+// ============================================================================
+// Control mode
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlMode {
+    Mit = 0,
+    Position = 1,
+    Velocity = 2,
+    Torque = 3,
+    Current = 4,
+}
+
+// ============================================================================
+// Parameter cache for SDO endpoint read/write
+// ============================================================================
+
+const DEFAULT_PARAM_TIMEOUT_MS: u64 = 200;
+const PARAM_POLL_INTERVAL_MS: u64 = 2;
+
+#[derive(Debug, Clone)]
+struct ParamCache {
+    /// Cached float values keyed by endpoint_id.
+    values: HashMap<u16, f32>,
+    /// Timestamp of last response for each endpoint_id.
+    reply_time: HashMap<u16, Instant>,
+    /// Write acknowledgment: endpoint_id → time of last ack.
+    write_ack_time: HashMap<u16, Instant>,
+    /// Pending read endpoint (if any).
+    pending_read: Option<u16>,
+    /// Pending write endpoint (if any).
+    pending_write: Option<u16>,
+}
+
+impl ParamCache {
+    fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+            reply_time: HashMap::new(),
+            write_ack_time: HashMap::new(),
+            pending_read: None,
+            pending_write: None,
+        }
+    }
+
+    fn record_read_response(&mut self, endpoint_id: u16, value: f32) {
+        self.values.insert(endpoint_id, value);
+        self.reply_time.insert(endpoint_id, Instant::now());
+        self.pending_read = None;
+    }
+
+    fn record_write_ack(&mut self, endpoint_id: u16) {
+        self.write_ack_time.insert(endpoint_id, Instant::now());
+        self.pending_write = None;
+    }
+}
+
+// ============================================================================
+// Default MIT limits (ODrive defaults)
+// ============================================================================
+
+const DEFAULT_MIT_POS_LIMIT: f32 = 12.5; // ± rad
+const DEFAULT_MIT_VEL_LIMIT: f32 = 50.0; // ± rad/s
+const DEFAULT_MIT_KP_LIMIT: f32 = 500.0; // max Kp
+const DEFAULT_MIT_KD_LIMIT: f32 = 100.0; // max Kd
+const DEFAULT_MIT_CURRENT_LIMIT: f32 = 40.0; // ± A (for response decoding)
+
+// ============================================================================
+// Motor state
+// ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+pub struct CyberBeastMotorState {
+    /// The CAN arbitration ID this state was decoded from.
+    pub arbitration_id: u32,
+    /// Parsed CAN ID fields.
+    pub can_id_parts: CyberBeastCanId,
+    /// Position in radians (output side).
+    pub pos: f32,
+    /// Velocity in rad/s (output side).
+    pub vel: f32,
+    /// Motor current in Amps.
+    pub current: f32,
+    /// Error code from MIT response.
+    pub error_code: u8,
+    /// Mode/state from MIT response.
+    pub mode_state: u8,
+    /// Motor temperature in °C.
+    pub motor_temp: f32,
+    /// MOSFET temperature in °C.
+    pub mos_temp: f32,
+    /// Life counter from heartbeat (if this was a heartbeat frame).
+    pub heartbeat_life: Option<u8>,
+    /// Raw axis error from heartbeat.
+    pub axis_error: Option<u16>,
+    /// Raw motor error from heartbeat.
+    pub motor_error: Option<u16>,
+    /// Raw encoder error from heartbeat.
+    pub encoder_error: Option<u16>,
+}
+
+impl Default for CyberBeastMotorState {
+    fn default() -> Self {
+        Self {
+            arbitration_id: 0,
+            can_id_parts: CyberBeastCanId {
+                priority: 0,
+                msg_type: 0,
+                dest: 0,
+                source: 0,
+                seq: 0,
+                is_broadcast: false,
+            },
+            pos: 0.0,
+            vel: 0.0,
+            current: 0.0,
+            error_code: 0,
+            mode_state: 0,
+            motor_temp: 0.0,
+            mos_temp: 0.0,
+            heartbeat_life: None,
+            axis_error: None,
+            motor_error: None,
+            encoder_error: None,
+        }
+    }
+}
+
+// ============================================================================
+// CyberBeastMotor
+// ============================================================================
+
+pub struct CyberBeastMotor {
+    /// CAN node ID of this motor device (destination for commands, source in responses).
+    pub motor_id: u16,
+    /// Master (host) CAN node ID. Used as source in outgoing frames.
+    pub master_id: u8,
+    /// Motor model string (must match a catalog entry).
+    pub model: String,
+    /// Shared CAN bus handle.
+    bus: Arc<dyn CanBus>,
+    /// Cached latest state from feedback/heartbeat frames.
+    state: Mutex<Option<CyberBeastMotorState>>,
+    /// Sequence number for outgoing commands (mod 4).
+    tx_seq: AtomicU8,
+    /// P/V/T limits derived from model catalog.
+    #[allow(dead_code)]
+    limits: PvTLimits,
+    /// MIT position limit for encoding (rad).
+    mit_pos_limit: f32,
+    /// MIT velocity limit for encoding (rad/s).
+    mit_vel_limit: f32,
+    /// MIT Kp limit for encoding.
+    mit_kp_limit: f32,
+    /// MIT Kd limit for encoding.
+    mit_kd_limit: f32,
+    /// MIT torque limit for encoding (N·m).
+    pub mit_torque_limit: f32,
+    /// Current limit for response decoding (A).
+    mit_current_limit: f32,
+    /// Parameter cache for SDO endpoint read/write operations.
+    param_cache: Mutex<ParamCache>,
+}
+
+impl CyberBeastMotor {
+    pub fn new(
+        motor_id: u16,
+        _feedback_id: u16,
+        model: &str,
+        bus: Arc<dyn CanBus>,
+    ) -> Result<Self> {
+        let spec = CYBERBEAST_CATALOG.get(model).ok_or_else(|| {
+            MotorError::InvalidArgument(format!("unknown cyberbeast model: {model}"))
+        })?;
+
+        Ok(Self {
+            motor_id,
+            master_id: DEFAULT_MASTER_ID,
+            model: model.to_string(),
+            bus,
+            state: Mutex::new(None),
+            tx_seq: AtomicU8::new(0),
+            limits: PvTLimits::from_spec(spec),
+            mit_pos_limit: DEFAULT_MIT_POS_LIMIT,
+            mit_vel_limit: DEFAULT_MIT_VEL_LIMIT,
+            mit_kp_limit: DEFAULT_MIT_KP_LIMIT,
+            mit_kd_limit: DEFAULT_MIT_KD_LIMIT,
+            mit_torque_limit: spec.tmax,
+            mit_current_limit: DEFAULT_MIT_CURRENT_LIMIT,
+            param_cache: Mutex::new(ParamCache::new()),
+        })
+    }
+
+    pub fn with_master_id(mut self, master_id: u8) -> Self {
+        self.master_id = master_id;
+        self
+    }
+
+    pub fn set_master_id(&mut self, master_id: u8) {
+        self.master_id = master_id;
+    }
+
+    pub fn latest_state(&self) -> Option<CyberBeastMotorState> {
+        self.state.lock().ok().and_then(|s| *s)
+    }
+
+    /// Get or compute the next transmit sequence number.
+    fn next_seq(&self) -> u8 {
+        let seq = self.tx_seq.load(Ordering::Relaxed);
+        self.tx_seq.store(seq_next(seq), Ordering::Relaxed);
+        seq
+    }
+
+    /// Build a CAN ID for a command to this motor.
+    fn cmd_can_id(&self, priority: Priority, msg_type: MsgType) -> u32 {
+        make_can_id(
+            priority as u8,
+            msg_type as u8,
+            self.motor_id as u8,
+            self.master_id,
+            self.next_seq(),
+        )
+    }
+
+    /// Build a broadcast CAN ID (reserved for future CAN FD broadcast support).
+    #[allow(dead_code)]
+    fn bcast_can_id(&self, priority: Priority, msg_type: MsgType) -> u32 {
+        // For broadcast, dest encodes a bitmask of target devices.
+        // For full broadcast, use 0xFF.
+        make_can_id(
+            priority as u8,
+            msg_type as u8,
+            0xFF,
+            self.master_id,
+            self.next_seq(),
+        )
+    }
+
+    /// Send a raw CAN frame with extended ID.
+    fn send_ext(&self, arbitration_id: u32, data: [u8; 8]) -> Result<()> {
+        self.bus.send(CanFrame {
+            arbitration_id,
+            data,
+            dlc: 8,
+            is_extended: true,
+            is_rx: false,
+        })
+    }
+
+    // ========================================================================
+    // Command methods
+    // ========================================================================
+
+    /// Send MIT (force-position-velocity) control command.
+    ///
+    /// Parameters are in output-side units:
+    /// - `pos`: target position (rad)
+    /// - `vel`: target velocity (rad/s)
+    /// - `kp`: position gain
+    /// - `kd`: velocity damping gain
+    /// - `torque`: feed-forward torque (N·m)
+    pub fn send_mit_command(
+        &self,
+        pos: f32,
+        vel: f32,
+        kp: f32,
+        kd: f32,
+        torque: f32,
+    ) -> Result<()> {
+        let params = MitCommandParams {
+            pos,
+            vel,
+            kp,
+            kd,
+            torque,
+        };
+        let data = pack_mit_command(
+            &params,
+            self.mit_pos_limit,
+            self.mit_vel_limit,
+            self.mit_kp_limit,
+            self.mit_kd_limit,
+            self.mit_torque_limit,
+        );
+        let can_id = self.cmd_can_id(Priority::HighCtrl, MsgType::MitControl);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send position control command (output-side units).
+    ///
+    /// - `target_pos_deg`: target position in degrees
+    /// - `vel_limit_rpm`: velocity limit in RPM
+    /// - `cur_limit_a`: current limit in Amps
+    pub fn send_pos_control(
+        &self,
+        target_pos_deg: f32,
+        vel_limit_rpm: f32,
+        cur_limit_a: f32,
+    ) -> Result<()> {
+        let data = encode_pos_control(target_pos_deg, vel_limit_rpm, cur_limit_a);
+        let can_id = self.cmd_can_id(Priority::Ctrl, MsgType::PosControl);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send velocity control command (output-side units).
+    ///
+    /// - `target_vel_rpm`: target velocity in RPM
+    /// - `cur_limit_a`: current limit in Amps
+    pub fn send_vel_control(&self, target_vel_rpm: f32, cur_limit_a: f32) -> Result<()> {
+        let data = encode_vel_control(target_vel_rpm, cur_limit_a);
+        let can_id = self.cmd_can_id(Priority::Ctrl, MsgType::VelControl);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send torque control command.
+    ///
+    /// - `target_torque_nm`: target torque in N·m
+    pub fn send_torque_control(&self, target_torque_nm: f32) -> Result<()> {
+        let data = encode_torque_control(target_torque_nm);
+        let can_id = self.cmd_can_id(Priority::Ctrl, MsgType::TorqueControl);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send direct current control command.
+    ///
+    /// - `target_current_a`: target current in Amps
+    pub fn send_current_control(&self, target_current_a: f32) -> Result<()> {
+        let data = encode_current_control(target_current_a);
+        let can_id = self.cmd_can_id(Priority::Ctrl, MsgType::CurrentControl);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send start motor command (enter closed-loop control).
+    pub fn send_start_motor(&self) -> Result<()> {
+        let can_id = self.cmd_can_id(Priority::Ctrl, MsgType::StartMotor);
+        self.send_ext(can_id, [0u8; 8])
+    }
+
+    /// Send stop motor command (enter IDLE).
+    pub fn send_stop_motor(&self) -> Result<()> {
+        let can_id = self.cmd_can_id(Priority::Ctrl, MsgType::StopMotor);
+        self.send_ext(can_id, [0u8; 8])
+    }
+
+    /// Send set-zero command (set current position as zero).
+    pub fn send_set_zero(&self) -> Result<()> {
+        let data = encode_set_zero();
+        let can_id = self.cmd_can_id(Priority::Config, MsgType::SetZero);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send clear-errors command.
+    pub fn send_clear_errors(&self) -> Result<()> {
+        let data = encode_clear_errors();
+        let can_id = self.cmd_can_id(Priority::Config, MsgType::ClearErrors);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send emergency stop.
+    pub fn send_estop(&self) -> Result<()> {
+        let can_id = self.cmd_can_id(Priority::Emergency, MsgType::Estop);
+        self.send_ext(can_id, [0u8; 8])
+    }
+
+    /// Send status query (requests MIT response).
+    pub fn send_query_status(&self) -> Result<()> {
+        let can_id = self.cmd_can_id(Priority::Query, MsgType::QueryStatus);
+        self.send_ext(can_id, [0u8; 8])
+    }
+
+    /// Send position+velocity query.
+    pub fn send_query_pos_vel(&self) -> Result<()> {
+        let can_id = self.cmd_can_id(Priority::Query, MsgType::QueryPosVel);
+        self.send_ext(can_id, [0u8; 8])
+    }
+
+    // ========================================================================
+    // Parameter (SDO endpoint) access
+    // ========================================================================
+
+    /// Send a parameter read request for an ODrive SDO endpoint.
+    pub fn send_param_read(&self, endpoint_id: u16) -> Result<()> {
+        {
+            let mut cache = self
+                .param_cache
+                .lock()
+                .map_err(|_| MotorError::Io("param cache lock poisoned".into()))?;
+            cache.pending_read = Some(endpoint_id);
+        }
+        let data = encode_param_read(endpoint_id);
+        let can_id = self.cmd_can_id(Priority::Config, MsgType::ParamRead);
+        self.send_ext(can_id, data)
+    }
+
+    /// Send a parameter write request for an ODrive SDO endpoint.
+    pub fn send_param_write(&self, endpoint_id: u16, value: f32) -> Result<()> {
+        {
+            let mut cache = self
+                .param_cache
+                .lock()
+                .map_err(|_| MotorError::Io("param cache lock poisoned".into()))?;
+            cache.pending_write = Some(endpoint_id);
+        }
+        let data = encode_param_write(endpoint_id, value);
+        let can_id = self.cmd_can_id(Priority::Config, MsgType::ParamWrite);
+        self.send_ext(can_id, data)
+    }
+
+    /// Read a parameter value, blocking until response or timeout.
+    pub fn get_param_f32(&self, endpoint_id: u16, timeout: Duration) -> Result<f32> {
+        self.wait_for_param(endpoint_id, timeout)
+    }
+
+    /// Write a parameter value and wait for acknowledgment.
+    pub fn set_param_f32(&self, endpoint_id: u16, value: f32) -> Result<()> {
+        self.send_param_write(endpoint_id, value)?;
+        self.wait_for_write_ack(endpoint_id, Duration::from_millis(DEFAULT_PARAM_TIMEOUT_MS))
+    }
+
+    /// Store parameters to flash (CONFIG_SAVE).
+    pub fn store_parameters(&self) -> Result<()> {
+        let data = encode_config_save();
+        let can_id = self.cmd_can_id(Priority::Config, MsgType::ConfigSave);
+        self.send_ext(can_id, data)
+    }
+
+    /// Block until a param read response arrives or timeout.
+    fn wait_for_param(&self, endpoint_id: u16, timeout: Duration) -> Result<f32> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            {
+                let cache = self
+                    .param_cache
+                    .lock()
+                    .map_err(|_| MotorError::Io("param cache lock poisoned".into()))?;
+                if let Some(ts) = cache.reply_time.get(&endpoint_id) {
+                    if *ts > Instant::now() - timeout {
+                        // Fresh value
+                        if let Some(val) = cache.values.get(&endpoint_id) {
+                            return Ok(*val);
+                        }
+                    }
+                }
+            }
+            if Instant::now() > deadline {
+                return Err(MotorError::Timeout(format!(
+                    "timeout waiting for param read 0x{endpoint_id:04X}",
+                )));
+            }
+            std::thread::sleep(Duration::from_millis(PARAM_POLL_INTERVAL_MS));
+        }
+    }
+
+    /// Block until a param write ack arrives or timeout.
+    fn wait_for_write_ack(&self, endpoint_id: u16, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            {
+                let cache = self
+                    .param_cache
+                    .lock()
+                    .map_err(|_| MotorError::Io("param cache lock poisoned".into()))?;
+                if let Some(ts) = cache.write_ack_time.get(&endpoint_id) {
+                    if *ts > Instant::now() - timeout {
+                        return Ok(());
+                    }
+                }
+            }
+            if Instant::now() > deadline {
+                return Err(MotorError::Timeout(format!(
+                    "timeout waiting for param write ack 0x{endpoint_id:04X}",
+                )));
+            }
+            std::thread::sleep(Duration::from_millis(PARAM_POLL_INTERVAL_MS));
+        }
+    }
+
+    // ========================================================================
+    // Feedback processing
+    // ========================================================================
+
+    /// Process an incoming frame: decode MIT response, heartbeat, or other feedback.
+    fn process_feedback_frame_impl(&self, frame: CanFrame) -> Result<()> {
+        let parts = can_id_parts(frame.arbitration_id);
+
+        match parts.msg_type {
+            // MIT response: reused MIT control msg type from motor → host
+            t if t == MsgType::MitControl as u8 => {
+                let resp = unpack_mit_response(
+                    &frame.data,
+                    self.mit_pos_limit,
+                    self.mit_vel_limit,
+                    self.mit_current_limit,
+                );
+
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|_| MotorError::Io("state lock poisoned".into()))?;
+                let existing = state.unwrap_or_default();
+
+                state.replace(CyberBeastMotorState {
+                    arbitration_id: frame.arbitration_id,
+                    can_id_parts: parts,
+                    pos: resp.pos,
+                    vel: resp.vel,
+                    current: resp.current,
+                    error_code: resp.error_code,
+                    mode_state: resp.mode_state,
+                    motor_temp: resp.motor_temp,
+                    mos_temp: resp.mos_temp,
+                    heartbeat_life: existing.heartbeat_life,
+                    axis_error: existing.axis_error,
+                    motor_error: existing.motor_error,
+                    encoder_error: existing.encoder_error,
+                });
+            }
+
+            // Heartbeat
+            t if t == MsgType::Heartbeat as u8 => {
+                if let Some(hb) = protocol::decode_heartbeat(&frame.data) {
+                    let mut state = self
+                        .state
+                        .lock()
+                        .map_err(|_| MotorError::Io("state lock poisoned".into()))?;
+                    let existing = state.unwrap_or_default();
+
+                    state.replace(CyberBeastMotorState {
+                        arbitration_id: frame.arbitration_id,
+                        can_id_parts: parts,
+                        heartbeat_life: Some(hb.life_counter),
+                        axis_error: Some(hb.axis_error),
+                        motor_error: Some(hb.motor_error),
+                        encoder_error: Some(hb.encoder_error),
+                        ..existing
+                    });
+                }
+            }
+
+            // QUERY_POS_VEL response
+            t if t == MsgType::QueryPosVel as u8 => {
+                let (pos, vel) = protocol::decode_pos_vel_response(&frame.data);
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|_| MotorError::Io("state lock poisoned".into()))?;
+                let existing = state.unwrap_or_default();
+                state.replace(CyberBeastMotorState {
+                    arbitration_id: frame.arbitration_id,
+                    can_id_parts: parts,
+                    pos,
+                    vel,
+                    ..existing
+                });
+            }
+
+            // QUERY_CURRENT response
+            t if t == MsgType::QueryCurrent as u8 => {
+                let (iq, _id) = protocol::decode_current_response(&frame.data);
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|_| MotorError::Io("state lock poisoned".into()))?;
+                let existing = state.unwrap_or_default();
+                state.replace(CyberBeastMotorState {
+                    arbitration_id: frame.arbitration_id,
+                    can_id_parts: parts,
+                    current: iq,
+                    ..existing
+                });
+            }
+
+            // QUERY_TEMPERATURE response
+            t if t == MsgType::QueryTemperature as u8 => {
+                let (motor_temp, mos_temp) = protocol::decode_temperature_response(&frame.data);
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|_| MotorError::Io("state lock poisoned".into()))?;
+                let existing = state.unwrap_or_default();
+                state.replace(CyberBeastMotorState {
+                    arbitration_id: frame.arbitration_id,
+                    can_id_parts: parts,
+                    motor_temp,
+                    mos_temp,
+                    ..existing
+                });
+            }
+
+            // QUERY_BUS response
+            t if t == MsgType::QueryBus as u8 => {
+                // Bus voltage/current — stored in state for now (could add dedicated fields)
+                let _ = protocol::decode_bus_response(&frame.data);
+            }
+
+            // PARAM_READ response
+            t if t == MsgType::ParamRead as u8 => {
+                // Parse endpoint_id from response
+                if frame.data.len() >= 3 {
+                    let endpoint_id = ((frame.data[1] as u16) << 8) | (frame.data[2] as u16);
+                    if let Some(val) =
+                        protocol::decode_param_read_response(&frame.data, endpoint_id)
+                    {
+                        let mut cache = self
+                            .param_cache
+                            .lock()
+                            .map_err(|_| MotorError::Io("param cache lock poisoned".into()))?;
+                        cache.record_read_response(endpoint_id, val);
+                    }
+                }
+            }
+
+            // PARAM_WRITE acknowledgment
+            t if t == MsgType::ParamWrite as u8 => {
+                if frame.data.len() >= 3 {
+                    let endpoint_id = ((frame.data[1] as u16) << 8) | (frame.data[2] as u16);
+                    if protocol::is_param_write_ack(&frame.data, endpoint_id) {
+                        let mut cache = self
+                            .param_cache
+                            .lock()
+                            .map_err(|_| MotorError::Io("param cache lock poisoned".into()))?;
+                        cache.record_write_ack(endpoint_id);
+                    }
+                }
+            }
+
+            _ => {
+                // Unknown response — ignore
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if a broadcast MIT control frame targets this motor (by slot position).
+    ///
+    /// Broadcast MIT frames encode up to 8 devices in 64-byte FD frames.
+    /// In CAN 2.0 mode, only slot 0 is used for point-to-point.
+    fn is_broadcast_slot_for_me(&self, parts: &CyberBeastCanId) -> bool {
+        let device_id = self.motor_id as u8;
+        if device_id == 0 || device_id >= MAX_BROADCAST_DEVICES {
+            return false;
+        }
+        // dest field encodes bitmask of target devices
+        (parts.dest & (1 << device_id)) != 0
+    }
+}
+
+// ============================================================================
+// MotorDevice trait impl
+// ============================================================================
+
+impl MotorDevice for CyberBeastMotor {
+    fn vendor(&self) -> &'static str {
+        "cyberbeast"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    fn motor_id(&self) -> u16 {
+        self.motor_id
+    }
+
+    fn feedback_id(&self) -> u16 {
+        // In CyberBeast protocol, feedback frames use the motor's node_id
+        // as the source address. Same as motor_id.
+        self.motor_id
+    }
+
+    fn enable(&self) -> Result<()> {
+        self.send_start_motor()
+    }
+
+    fn disable(&self) -> Result<()> {
+        self.send_stop_motor()
+    }
+
+    fn accepts_frame(&self, frame: &CanFrame) -> bool {
+        if !frame.is_rx {
+            return false;
+        }
+        let parts = can_id_parts(frame.arbitration_id);
+
+        // Point-to-point: source matches our motor_id
+        if !parts.is_broadcast {
+            return parts.source == self.motor_id as u8;
+        }
+
+        // Broadcast: check bitmask in dest field
+        self.is_broadcast_slot_for_me(&parts)
+    }
+
+    fn process_feedback_frame(&self, frame: CanFrame) -> Result<()> {
+        self.process_feedback_frame_impl(frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use motor_core::bus::{CanBus, CanFrame};
+    use motor_core::test_support::MockBus;
+    use std::sync::Arc;
+
+    fn make_motor() -> CyberBeastMotor {
+        let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
+        CyberBeastMotor::new(0x01, 0x01, "odrive-default", bus).unwrap()
+    }
+
+    #[test]
+    fn test_model_catalog() {
+        let spec = CYBERBEAST_CATALOG.get("odrive-default").unwrap();
+        assert_eq!(spec.vendor, "cyberbeast");
+        assert_eq!(spec.model, "odrive-default");
+    }
+
+    #[test]
+    fn test_unknown_model_rejected() {
+        let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
+        let result = CyberBeastMotor::new(0x01, 0x01, "nonexistent", bus);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_can_id_roundtrip() {
+        let id = make_can_id(2, 0x00, 0x01, 0x0A, 1);
+        let parts = can_id_parts(id);
+        assert_eq!(parts.priority, 2);
+        assert_eq!(parts.msg_type, 0x00); // MIT_CONTROL
+        assert_eq!(parts.dest, 0x01);
+        assert_eq!(parts.source, 0x0A);
+        assert_eq!(parts.seq, 1);
+        assert!(!parts.is_broadcast);
+    }
+
+    #[test]
+    fn test_broadcast_detection() {
+        let id = make_can_id(2, 0x80, 0xFF, 0x0A, 0);
+        let parts = can_id_parts(id);
+        assert!(parts.is_broadcast);
+    }
+
+    #[test]
+    fn test_mit_pack_unpack_roundtrip() {
+        let params = MitCommandParams {
+            pos: 1.5,
+            vel: 10.0,
+            kp: 100.0,
+            kd: 5.0,
+            torque: 0.5,
+        };
+        let packed = pack_mit_command(&params, 12.5, 50.0, 500.0, 100.0, 10.0);
+        let unpacked = protocol::unpack_mit_command(&packed, 12.5, 50.0, 500.0, 100.0, 10.0);
+
+        // Due to quantization, compare with tolerance
+        assert!((unpacked.pos - 1.5).abs() < 0.01);
+        assert!((unpacked.vel - 10.0).abs() < 0.1);
+        assert!((unpacked.kp - 100.0).abs() < 1.0);
+        assert!((unpacked.kd - 5.0).abs() < 0.1);
+        assert!((unpacked.torque - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_mit_response_decode() {
+        // Verify decode of zero-filled MIT response doesn't panic and returns defaults
+        let resp = unpack_mit_response(&[0u8; 8], 12.5, 50.0, 40.0);
+        assert_eq!(resp.error_code, 0);
+        assert_eq!(resp.mode_state, 0);
+    }
+
+    #[test]
+    fn test_accepts_frame() {
+        let motor = make_motor();
+        // Frame from our motor (source == motor_id)
+        let id = make_can_id(2, 0x00, 0x0A, 0x01, 0); // source=0x01 matches motor_id=1
+        let frame = CanFrame {
+            arbitration_id: id,
+            data: [0u8; 8],
+            dlc: 8,
+            is_extended: true,
+            is_rx: true,
+        };
+        assert!(motor.accepts_frame(&frame));
+
+        // Frame from a different motor
+        let id2 = make_can_id(2, 0x00, 0x0A, 0x02, 0); // source=0x02
+        let frame2 = CanFrame {
+            arbitration_id: id2,
+            data: [0u8; 8],
+            dlc: 8,
+            is_extended: true,
+            is_rx: true,
+        };
+        assert!(!motor.accepts_frame(&frame2));
+
+        // TX frame should not be accepted
+        let frame3 = CanFrame {
+            arbitration_id: id,
+            data: [0u8; 8],
+            dlc: 8,
+            is_extended: true,
+            is_rx: false,
+        };
+        assert!(!motor.accepts_frame(&frame3));
+    }
+
+    #[test]
+    fn test_send_mit_command_encodes_correct_frame() {
+        let mock_bus: Arc<MockBus> = Arc::new(MockBus::new());
+        let bus: Arc<dyn CanBus> = Arc::clone(&mock_bus) as Arc<dyn CanBus>;
+        let motor = CyberBeastMotor::new(0x01, 0x01, "odrive-default", bus).unwrap();
+
+        motor.send_mit_command(1.0, 0.5, 100.0, 10.0, 0.2).unwrap();
+
+        let sent: Vec<CanFrame> = mock_bus.sent.lock().unwrap().drain(..).collect();
+        assert_eq!(sent.len(), 1);
+        let frame = &sent[0];
+        assert!(frame.is_extended);
+        assert!(!frame.is_rx);
+
+        // Verify CAN ID: Priority=2(HighCtrl), MsgType=0x00(MIT), dest=0x01, source=0x01
+        let parts = can_id_parts(frame.arbitration_id);
+        assert_eq!(parts.priority, Priority::HighCtrl as u8);
+        assert_eq!(parts.msg_type, MsgType::MitControl as u8);
+        assert_eq!(parts.dest, 0x01);
+        assert_eq!(parts.source, DEFAULT_MASTER_ID);
+    }
+
+    #[test]
+    fn test_mit_response_process_updates_state() {
+        let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
+        let motor = CyberBeastMotor::new(0x02, 0x02, "odrive-default", Arc::clone(&bus)).unwrap();
+
+        // Build a mock MIT response frame
+        // pos=1.0 rad, vel=2.0 rad/s, current=3.0 A, error=0, mode=4(MIT)
+        let params = MitCommandParams {
+            pos: 1.0,
+            vel: 2.0,
+            kp: 0.0,
+            kd: 0.0,
+            torque: 3.0, // Using torque value to represent current in packed form
+        };
+        let packed = pack_mit_command(&params, 12.5, 50.0, 500.0, 100.0, 40.0);
+
+        let can_id = make_can_id(2, MsgType::MitControl as u8, 0x0A, 0x02, 0);
+        let frame = CanFrame {
+            arbitration_id: can_id,
+            data: packed,
+            dlc: 8,
+            is_extended: true,
+            is_rx: true,
+        };
+
+        motor.process_feedback_frame(frame).unwrap();
+
+        let state = motor.latest_state().unwrap();
+        // With packed MIT command layout mapped to response decode, values won't match
+        // exactly, but state should be populated
+        assert!(state.pos != 0.0 || state.vel != 0.0 || state.current != 0.0);
+        assert_eq!(state.can_id_parts.source, 0x02);
+    }
+
+    #[test]
+    fn test_heartbeat_decode_updates_state() {
+        let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
+        let motor = CyberBeastMotor::new(0x03, 0x03, "odrive-default", Arc::clone(&bus)).unwrap();
+
+        // Build a mock heartbeat frame
+        let mut data = [0u8; 8];
+        data[0] = 42; // life_counter
+        data[1] = 0x03; // device_id
+        data[2] = 0x00;
+        data[3] = 0x01; // axis_error = 1
+        data[4] = 0x00;
+        data[5] = 0x00; // motor_error = 0
+        data[6] = 0x00;
+        data[7] = 0x00; // encoder_error = 0
+
+        let can_id = make_can_id(6, MsgType::Heartbeat as u8, 0x01, 0x03, 0);
+        let frame = CanFrame {
+            arbitration_id: can_id,
+            data,
+            dlc: 8,
+            is_extended: true,
+            is_rx: true,
+        };
+
+        motor.process_feedback_frame(frame).unwrap();
+
+        let state = motor.latest_state().unwrap();
+        assert_eq!(state.heartbeat_life, Some(42));
+        assert_eq!(state.axis_error, Some(1));
+        assert_eq!(state.motor_error, Some(0));
+    }
+
+    #[test]
+    fn test_process_mit_response_updates_core_fields() {
+        let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
+        let motor = CyberBeastMotor::new(0x04, 0x04, "odrive-default", Arc::clone(&bus)).unwrap();
+
+        // Build a proper MIT response (different layout from MIT command)
+        // Response: pos(16-bit), vel(12-bit)+error(4-bit), current(12-bit)+mode(4-bit), motor_temp, mos_temp
+        // Use mid-range values: pos=0x8000, vel=0x0800, error=0, current=0x0800, mode=3
+        let buf: [u8; 8] = [
+            0x80, 0x00, // pos mid-range
+            0x80, 0x00, // vel mid-range + error=0
+            0x80, 0x03, // current mid-range + mode=3 (CLOSED_LOOP)
+            0x6E, // motor_temp=110 → actual = 60°C
+            0x6E, // mos_temp=110 → actual = 60°C
+        ];
+
+        let can_id = make_can_id(2, MsgType::MitControl as u8, 0x01, 0x04, 0);
+        let frame = CanFrame {
+            arbitration_id: can_id,
+            data: buf,
+            dlc: 8,
+            is_extended: true,
+            is_rx: true,
+        };
+
+        motor.process_feedback_frame(frame).unwrap();
+
+        let state = motor.latest_state().unwrap();
+        assert_eq!(state.mode_state, 3); // CLOSED_LOOP
+        assert_eq!(state.error_code, 0);
+        assert!((state.motor_temp - 60.0).abs() < 1.0);
+        assert!((state.mos_temp - 60.0).abs() < 1.0);
+    }
+}

--- a/motor_vendors/cyberbeast/src/protocol.rs
+++ b/motor_vendors/cyberbeast/src/protocol.rs
@@ -1,0 +1,795 @@
+//! CyberBeast CAN protocol — Big-Endian, extended 29-bit CAN ID with J1939-like layout.
+//!
+//! CAN ID layout (29-bit extended):
+//!   Priority[28:26] | MsgType[25:18] | Dest[17:10] | Source[9:2] | Seq[1:0]
+//!
+//! Design principles:
+//! - Big-Endian (Motorola) byte order for all multi-byte payloads.
+//! - Implicit addressing: MsgType < 0x80 = point-to-point, MsgType >= 0x80 = broadcast.
+//! - 3-bit priority (8 levels, J1939 style).
+//! - 2-bit sequence number for loss detection.
+//!
+//! Reference: ODrive Firmware/communication/can/can_cyberbeast.hpp
+
+// ============================================================================
+// CAN ID bit layout
+// ============================================================================
+
+pub const PRIORITY_SHIFT: u32 = 26;
+pub const MSGTYPE_SHIFT: u32 = 18;
+pub const DEST_SHIFT: u32 = 10;
+pub const SOURCE_SHIFT: u32 = 2;
+pub const SEQ_SHIFT: u32 = 0;
+
+pub const PRIORITY_MASK: u32 = 0x7;
+pub const MSGTYPE_MASK: u32 = 0xFF;
+pub const DEST_MASK: u32 = 0xFF;
+pub const SOURCE_MASK: u32 = 0xFF;
+pub const SEQ_MASK: u32 = 0x3;
+
+/// MsgType threshold: values >= this are broadcast (J1939 PDU2 style).
+pub const MSGTYPE_BROADCAST_THRESHOLD: u8 = 0x80;
+
+/// Broadcast address value in the Dest field for non-multicast broadcast frames.
+pub const ADDR_BROADCAST: u8 = 0xFF;
+
+/// Maximum number of devices addressable in a single broadcast slot frame.
+pub const MAX_BROADCAST_DEVICES: u8 = 8;
+
+/// Default master (host) node address.
+pub const DEFAULT_MASTER_ID: u8 = 0x01;
+
+// ============================================================================
+// Priority (3-bit, 8 levels, J1939 style)
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Priority {
+    Critical = 0,
+    Emergency = 1,
+    HighCtrl = 2,
+    Ctrl = 3,
+    Config = 4,
+    Query = 5,
+    Status = 6,
+    Low = 7,
+}
+
+impl Priority {
+    pub fn from_u8(v: u8) -> Self {
+        match v & PRIORITY_MASK as u8 {
+            0 => Self::Critical,
+            1 => Self::Emergency,
+            2 => Self::HighCtrl,
+            3 => Self::Ctrl,
+            4 => Self::Config,
+            5 => Self::Query,
+            6 => Self::Status,
+            _ => Self::Low,
+        }
+    }
+}
+
+// ============================================================================
+// MsgType (8-bit, 256 message types)
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MsgType {
+    // --- Point-to-point real-time control (0x00–0x1F) ---
+    MitControl = 0x00,
+    PosControl = 0x01,
+    VelControl = 0x02,
+    TorqueControl = 0x03,
+    CurrentControl = 0x04,
+
+    // --- Point-to-point config management (0x20–0x3F) ---
+    ParamRead = 0x20,
+    ParamWrite = 0x21,
+    ConfigSave = 0x22,
+    ConfigReset = 0x23,
+    JsonDescRead = 0x24,
+    JsonDescData = 0x25,
+
+    // --- Point-to-point status queries (0x40–0x5F) ---
+    QueryStatus = 0x40,
+    QueryPosVel = 0x41,
+    QueryCurrent = 0x42,
+    QueryTemperature = 0x43,
+    QueryBus = 0x44,
+    QueryError = 0x45,
+    QueryDeviceInfo = 0x46,
+    QueryPower = 0x47,
+    Heartbeat = 0x48,
+    StatusFeedback = 0x49,
+
+    // --- Point-to-point system management (0x60–0x7F) ---
+    SetNodeId = 0x60,
+    SetZero = 0x61,
+    StartMotor = 0x62,
+    StopMotor = 0x63,
+    ResetDevice = 0x64,
+    ClearErrors = 0x65,
+
+    // --- Broadcast real-time control (0x80–0x9F) ---
+    MitControlBcast = 0x80,
+    PosControlBcast = 0x81,
+    VelControlBcast = 0x82,
+    TorqueControlBcast = 0x83,
+
+    // --- Broadcast emergency/system (0xC0–0xDF) ---
+    Estop = 0xC0,
+    FaultAlert = 0xC1,
+}
+
+impl MsgType {
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0x00 => Self::MitControl,
+            0x01 => Self::PosControl,
+            0x02 => Self::VelControl,
+            0x03 => Self::TorqueControl,
+            0x04 => Self::CurrentControl,
+            0x20 => Self::ParamRead,
+            0x21 => Self::ParamWrite,
+            0x22 => Self::ConfigSave,
+            0x23 => Self::ConfigReset,
+            0x24 => Self::JsonDescRead,
+            0x25 => Self::JsonDescData,
+            0x40 => Self::QueryStatus,
+            0x41 => Self::QueryPosVel,
+            0x42 => Self::QueryCurrent,
+            0x43 => Self::QueryTemperature,
+            0x44 => Self::QueryBus,
+            0x45 => Self::QueryError,
+            0x46 => Self::QueryDeviceInfo,
+            0x47 => Self::QueryPower,
+            0x48 => Self::Heartbeat,
+            0x49 => Self::StatusFeedback,
+            0x60 => Self::SetNodeId,
+            0x61 => Self::SetZero,
+            0x62 => Self::StartMotor,
+            0x63 => Self::StopMotor,
+            0x64 => Self::ResetDevice,
+            0x65 => Self::ClearErrors,
+            0x80 => Self::MitControlBcast,
+            0x81 => Self::PosControlBcast,
+            0x82 => Self::VelControlBcast,
+            0x83 => Self::TorqueControlBcast,
+            0xC0 => Self::Estop,
+            0xC1 => Self::FaultAlert,
+            _ => {
+                // Unknown type: preserve raw value semantics
+                // is_broadcast is determined by >= MSGTYPE_BROADCAST_THRESHOLD
+                Self::MitControl // safe fallback for routing purposes
+            }
+        }
+    }
+
+    pub fn is_broadcast(&self) -> bool {
+        (*self as u8) >= MSGTYPE_BROADCAST_THRESHOLD
+    }
+}
+
+// ============================================================================
+// Error codes in MIT response
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ErrorCode {
+    None = 0x0,
+    Motor = 0x1,
+    Encoder = 0x2,
+    Controller = 0x3,
+    UnderVoltage = 0x4,
+    OverTemp = 0x5,
+    OverCurrent = 0x6,
+    Stall = 0x7,
+    CanTimeout = 0x8,
+    Multiple = 0xF,
+}
+
+impl ErrorCode {
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0x0 => Self::None,
+            0x1 => Self::Motor,
+            0x2 => Self::Encoder,
+            0x3 => Self::Controller,
+            0x4 => Self::UnderVoltage,
+            0x5 => Self::OverTemp,
+            0x6 => Self::OverCurrent,
+            0x7 => Self::Stall,
+            0x8 => Self::CanTimeout,
+            _ => Self::Multiple,
+        }
+    }
+}
+
+// ============================================================================
+// Mode state in MIT response
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ModeState {
+    Reset = 0x0,
+    Calibrating = 0x1,
+    Idle = 0x2,
+    ClosedLoop = 0x3,
+    Mit = 0x4,
+    Position = 0x5,
+    Velocity = 0x6,
+    Torque = 0x7,
+}
+
+impl ModeState {
+    pub fn from_u8(v: u8) -> u8 {
+        // Return raw value; caller can interpret
+        v & 0x0F
+    }
+
+    pub fn name(v: u8) -> &'static str {
+        match v & 0x0F {
+            0x0 => "reset",
+            0x1 => "calibrating",
+            0x2 => "idle",
+            0x3 => "closed_loop",
+            0x4 => "mit",
+            0x5 => "position",
+            0x6 => "velocity",
+            0x7 => "torque",
+            _ => "unknown",
+        }
+    }
+}
+
+// ============================================================================
+// Parsed CAN ID
+// ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+pub struct CyberBeastCanId {
+    pub priority: u8,
+    pub msg_type: u8,
+    pub dest: u8,
+    pub source: u8,
+    pub seq: u8,
+    pub is_broadcast: bool,
+}
+
+// ============================================================================
+// CAN ID encode / decode
+// ============================================================================
+
+/// Build a 29-bit extended CAN ID from CyberBeast protocol fields.
+pub const fn make_can_id(priority: u8, msg_type: u8, dest: u8, source: u8, seq: u8) -> u32 {
+    ((priority & PRIORITY_MASK as u8) as u32) << PRIORITY_SHIFT
+        | (msg_type as u32) << MSGTYPE_SHIFT
+        | ((dest & DEST_MASK as u8) as u32) << DEST_SHIFT
+        | ((source & SOURCE_MASK as u8) as u32) << SOURCE_SHIFT
+        | ((seq & SEQ_MASK as u8) as u32) << SEQ_SHIFT
+}
+
+/// Parse a 29-bit CAN ID into its CyberBeast protocol fields.
+pub fn can_id_parts(can_id: u32) -> CyberBeastCanId {
+    let msg_type = ((can_id >> MSGTYPE_SHIFT) & MSGTYPE_MASK) as u8;
+    CyberBeastCanId {
+        priority: ((can_id >> PRIORITY_SHIFT) & PRIORITY_MASK) as u8,
+        msg_type,
+        dest: ((can_id >> DEST_SHIFT) & DEST_MASK) as u8,
+        source: ((can_id >> SOURCE_SHIFT) & SOURCE_MASK) as u8,
+        seq: ((can_id >> SEQ_SHIFT) & SEQ_MASK) as u8,
+        is_broadcast: msg_type >= MSGTYPE_BROADCAST_THRESHOLD,
+    }
+}
+
+/// Increment sequence number (mod 4).
+pub const fn seq_next(seq: u8) -> u8 {
+    (seq + 1) & SEQ_MASK as u8
+}
+
+// ============================================================================
+// Big-Endian float32 encoding
+// ============================================================================
+
+pub fn big_endian_bytes_to_f32(buf: &[u8], offset: usize) -> f32 {
+    if offset + 4 > buf.len() {
+        return 0.0;
+    }
+    let raw = ((buf[offset] as u32) << 24)
+        | ((buf[offset + 1] as u32) << 16)
+        | ((buf[offset + 2] as u32) << 8)
+        | (buf[offset + 3] as u32);
+    f32::from_bits(raw)
+}
+
+pub fn f32_to_big_endian_bytes(val: f32, buf: &mut [u8], offset: usize) {
+    if offset + 4 > buf.len() {
+        return;
+    }
+    let raw = val.to_bits();
+    buf[offset] = (raw >> 24) as u8;
+    buf[offset + 1] = (raw >> 16) as u8;
+    buf[offset + 2] = (raw >> 8) as u8;
+    buf[offset + 3] = raw as u8;
+}
+
+// ============================================================================
+// Float/int range mapping (replicates ODrive float_to_uint / uint_to_float)
+// ============================================================================
+
+fn float_to_uint(x: f32, x_min: f32, x_max: f32, bits: u32) -> u32 {
+    let span = x_max - x_min;
+    if span <= 0.0 {
+        return 0;
+    }
+    let max_val = (1u32 << bits) - 1;
+    let clamped = x.clamp(x_min, x_max);
+    ((clamped - x_min) / span * max_val as f32).round() as u32
+}
+
+fn uint_to_float(x_int: u32, x_min: f32, x_max: f32, bits: u32) -> f32 {
+    let max_val = (1u32 << bits) - 1;
+    let span = x_max - x_min;
+    x_min + (x_int as f32 / max_val as f32) * span
+}
+
+// ============================================================================
+// MIT command pack (8 bytes per device, Big-Endian bit-packed)
+//
+// Layout per 8-byte slot:
+//   Byte 0-1:  pos       [15:0]   16-bit
+//   Byte 2-3:  vel[11:0] | kp[11:8]  12-bit vel + 4-bit kp high
+//   Byte 4:    kp[7:0]             kp low
+//   Byte 5-6:  kd[11:0] | torque[11:8]  12-bit kd + 4-bit torque high
+//   Byte 7:    torque[7:0]          torque low
+// ============================================================================
+
+pub struct MitCommandParams {
+    pub pos: f32,
+    pub vel: f32,
+    pub kp: f32,
+    pub kd: f32,
+    pub torque: f32,
+}
+
+impl Default for MitCommandParams {
+    fn default() -> Self {
+        Self {
+            pos: 0.0,
+            vel: 0.0,
+            kp: 0.0,
+            kd: 0.0,
+            torque: 0.0,
+        }
+    }
+}
+
+pub fn pack_mit_command(
+    params: &MitCommandParams,
+    pos_limit: f32,
+    vel_limit: f32,
+    kp_limit: f32,
+    kd_limit: f32,
+    torque_limit: f32,
+) -> [u8; 8] {
+    let p_int = float_to_uint(params.pos, -pos_limit, pos_limit, 16);
+    let v_int = float_to_uint(params.vel, -vel_limit, vel_limit, 12);
+    let kp_int = float_to_uint(params.kp, 0.0, kp_limit, 12);
+    let kd_int = float_to_uint(params.kd, 0.0, kd_limit, 12);
+    let t_int = float_to_uint(params.torque, -torque_limit, torque_limit, 12);
+
+    let mut buf = [0u8; 8];
+    buf[0] = (p_int >> 8) as u8;
+    buf[1] = p_int as u8;
+    buf[2] = (v_int >> 4) as u8;
+    buf[3] = ((v_int & 0x0F) << 4) as u8 | ((kp_int >> 8) & 0x0F) as u8;
+    buf[4] = kp_int as u8;
+    buf[5] = (kd_int >> 4) as u8;
+    buf[6] = ((kd_int & 0x0F) << 4) as u8 | ((t_int >> 8) & 0x0F) as u8;
+    buf[7] = t_int as u8;
+    buf
+}
+
+pub fn unpack_mit_command(
+    data: &[u8],
+    pos_limit: f32,
+    vel_limit: f32,
+    kp_limit: f32,
+    kd_limit: f32,
+    torque_limit: f32,
+) -> MitCommandParams {
+    if data.len() < 8 {
+        return MitCommandParams::default();
+    }
+    let p_int = ((data[0] as u16) << 8) | (data[1] as u16);
+    let v_int = ((data[2] as u16) << 4) | ((data[3] >> 4) as u16);
+    let kp_int = (((data[3] & 0x0F) as u16) << 8) | (data[4] as u16);
+    let kd_int = ((data[5] as u16) << 4) | ((data[6] >> 4) as u16);
+    let t_int = (((data[6] & 0x0F) as u16) << 8) | (data[7] as u16);
+
+    MitCommandParams {
+        pos: uint_to_float(p_int as u32, -pos_limit, pos_limit, 16),
+        vel: uint_to_float(v_int as u32, -vel_limit, vel_limit, 12),
+        kp: uint_to_float(kp_int as u32, 0.0, kp_limit, 12),
+        kd: uint_to_float(kd_int as u32, 0.0, kd_limit, 12),
+        torque: uint_to_float(t_int as u32, -torque_limit, torque_limit, 12),
+    }
+}
+
+// ============================================================================
+// MIT response unpack
+//
+// Layout (8 bytes):
+//   Byte 0-1:  pos         [15:0]   16-bit
+//   Byte 2-3:  vel[11:0] | error[3:0]  12-bit vel + 4-bit error code
+//   Byte 4-5:  current[11:0] | mode[3:0] 12-bit current + 4-bit mode
+//   Byte 6:    motor_temp    u8 (offset -50: actual = raw - 50)
+//   Byte 7:    mos_temp      u8 (offset -50)
+// ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+pub struct MitResponse {
+    pub pos: f32,
+    pub vel: f32,
+    pub current: f32,
+    pub error_code: u8,
+    pub mode_state: u8,
+    pub motor_temp: f32,
+    pub mos_temp: f32,
+}
+
+pub fn unpack_mit_response(
+    data: &[u8],
+    pos_limit: f32,
+    vel_limit: f32,
+    current_limit: f32,
+) -> MitResponse {
+    if data.len() < 8 {
+        return MitResponse {
+            pos: 0.0,
+            vel: 0.0,
+            current: 0.0,
+            error_code: 0,
+            mode_state: 0,
+            motor_temp: 0.0,
+            mos_temp: 0.0,
+        };
+    }
+
+    let p_int = ((data[0] as u16) << 8) | (data[1] as u16);
+    let v_int = ((data[2] as u16) << 4) | ((data[3] >> 4) as u16);
+    let error = data[3] & 0x0F;
+    let c_int = ((data[4] as u16) << 4) | ((data[5] >> 4) as u16);
+    let mode = data[5] & 0x0F;
+    let motor_temp_raw = data[6];
+    let mos_temp_raw = data[7];
+
+    MitResponse {
+        pos: uint_to_float(p_int as u32, -pos_limit, pos_limit, 16),
+        vel: uint_to_float(v_int as u32, -vel_limit, vel_limit, 12),
+        current: uint_to_float(c_int as u32, -current_limit, current_limit, 12),
+        error_code: error,
+        mode_state: mode,
+        motor_temp: motor_temp_raw as f32 - 50.0,
+        mos_temp: mos_temp_raw as f32 - 50.0,
+    }
+}
+
+// ============================================================================
+// POS/VOL/TORQUE/CURRENT control encode
+// ============================================================================
+
+/// Encode POS_CONTROL frame (8-byte CAN 2.0 compatible).
+///
+/// Encodes target position and velocity limit as two float32 BE values.
+/// Current limit is omitted — set it separately via PARAM_WRITE (endpoint 0x001C:
+/// `motor.config.current_lim`) or use the existing device configuration.
+///
+/// For full 12-byte encoding (including cur_limit), use CAN FD frames.
+pub fn encode_pos_control(target_pos_deg: f32, vel_limit_rpm: f32, _cur_limit_a: f32) -> [u8; 8] {
+    let mut buf = [0u8; 8];
+    f32_to_big_endian_bytes(target_pos_deg, &mut buf, 0);
+    f32_to_big_endian_bytes(vel_limit_rpm, &mut buf, 4);
+    buf
+}
+
+/// Encode VEL_CONTROL frame: float32 target_vel(RPM) + float32 cur_limit(A)
+pub fn encode_vel_control(target_vel_rpm: f32, cur_limit_a: f32) -> [u8; 8] {
+    let mut buf = [0u8; 8];
+    f32_to_big_endian_bytes(target_vel_rpm, &mut buf, 0);
+    f32_to_big_endian_bytes(cur_limit_a, &mut buf, 4);
+    buf
+}
+
+/// Encode TORQUE_CONTROL frame: float32 target_torque(N·m)
+pub fn encode_torque_control(target_torque_nm: f32) -> [u8; 8] {
+    let mut buf = [0u8; 8];
+    f32_to_big_endian_bytes(target_torque_nm, &mut buf, 0);
+    buf
+}
+
+/// Encode CURRENT_CONTROL frame: float32 target_current(A)
+pub fn encode_current_control(target_current_a: f32) -> [u8; 8] {
+    let mut buf = [0u8; 8];
+    f32_to_big_endian_bytes(target_current_a, &mut buf, 0);
+    buf
+}
+
+// ============================================================================
+// System management command encodes
+// ============================================================================
+
+pub fn encode_set_zero() -> [u8; 8] {
+    [0u8; 8]
+}
+
+pub fn encode_clear_errors() -> [u8; 8] {
+    [0u8; 8]
+}
+
+// ============================================================================
+// Heartbeat decode
+//
+// CAN 2.0 heartbeat (8 bytes):
+//   Byte 0:    life_counter
+//   Byte 1:    device_id
+//   Byte 2-3:  axis_error   (uint16, BE)
+//   Byte 4-5:  motor_error  (uint16, BE)
+//   Byte 6-7:  encoder_error (uint16, BE)
+// ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+pub struct HeartbeatFrame {
+    pub life_counter: u8,
+    pub device_id: u8,
+    pub axis_error: u16,
+    pub motor_error: u16,
+    pub encoder_error: u16,
+}
+
+pub fn decode_heartbeat(data: &[u8]) -> Option<HeartbeatFrame> {
+    if data.len() < 8 {
+        return None;
+    }
+    Some(HeartbeatFrame {
+        life_counter: data[0],
+        device_id: data[1],
+        axis_error: ((data[2] as u16) << 8) | (data[3] as u16),
+        motor_error: ((data[4] as u16) << 8) | (data[5] as u16),
+        encoder_error: ((data[6] as u16) << 8) | (data[7] as u16),
+    })
+}
+
+// ============================================================================
+// POS/VOL response decode
+// ============================================================================
+
+/// Decode a QUERY_POS_VEL response: 2× float32 BE (pos turns, vel turns/s)
+pub fn decode_pos_vel_response(data: &[u8]) -> (f32, f32) {
+    if data.len() < 8 {
+        return (0.0, 0.0);
+    }
+    let pos = big_endian_bytes_to_f32(data, 0);
+    let vel = big_endian_bytes_to_f32(data, 4);
+    (pos, vel)
+}
+
+/// Decode a QUERY_CURRENT response: 2× float32 BE (iq, id)
+pub fn decode_current_response(data: &[u8]) -> (f32, f32) {
+    if data.len() < 8 {
+        return (0.0, 0.0);
+    }
+    let iq = big_endian_bytes_to_f32(data, 0);
+    let id = big_endian_bytes_to_f32(data, 4);
+    (iq, id)
+}
+
+/// Decode a QUERY_TEMPERATURE response: 2× float32 BE (motor_temp °C, fet_temp °C)
+pub fn decode_temperature_response(data: &[u8]) -> (f32, f32) {
+    if data.len() < 8 {
+        return (0.0, 0.0);
+    }
+    let motor_temp = big_endian_bytes_to_f32(data, 0);
+    let fet_temp = big_endian_bytes_to_f32(data, 4);
+    (motor_temp, fet_temp)
+}
+
+/// Decode a QUERY_BUS response: 2× float32 BE (vbus V, ibus A)
+pub fn decode_bus_response(data: &[u8]) -> (f32, f32) {
+    if data.len() < 8 {
+        return (0.0, 0.0);
+    }
+    let vbus = big_endian_bytes_to_f32(data, 0);
+    let ibus = big_endian_bytes_to_f32(data, 4);
+    (vbus, ibus)
+}
+
+// ============================================================================
+// Parameter (SDO endpoint) read/write encode/decode
+//
+// PARAM_READ request (8 bytes):
+//   Byte 0:    flags (0x00 for read)
+//   Byte 1-2:  endpoint_id (uint16, BE)
+//   Byte 3:    data_len (0 for read request)
+//   Byte 4-7:  reserved (0)
+//
+// PARAM_READ response (8 bytes):
+//   Byte 0:    flags (echo)
+//   Byte 1-2:  endpoint_id (uint16, BE)
+//   Byte 3:    data_len = 4
+//   Byte 4-7:  value (float32, BE)
+//
+// PARAM_WRITE request (8 bytes):
+//   Byte 0:    flags (0x00 for write)
+//   Byte 1-2:  endpoint_id (uint16, BE)
+//   Byte 3:    data_len = 4
+//   Byte 4-7:  value (float32, BE)
+//
+// PARAM_WRITE response (8 bytes):
+//   Byte 0:    flags (echo)
+//   Byte 1-2:  endpoint_id (uint16, BE)
+//   Byte 3:    data_len = 0 (write confirmation)
+//   Byte 4-7:  reserved (0)
+// ============================================================================
+
+/// Encode a PARAM_READ request frame for an ODrive SDO endpoint.
+pub fn encode_param_read(endpoint_id: u16) -> [u8; 8] {
+    let mut buf = [0u8; 8];
+    buf[0] = 0x00; // flags
+    buf[1] = (endpoint_id >> 8) as u8;
+    buf[2] = endpoint_id as u8;
+    buf[3] = 0x00; // data_len = 0 (read request)
+    // bytes 4-7 remain zero
+    buf
+}
+
+/// Encode a PARAM_WRITE request frame for an ODrive SDO endpoint.
+pub fn encode_param_write(endpoint_id: u16, value: f32) -> [u8; 8] {
+    let mut buf = [0u8; 8];
+    buf[0] = 0x00; // flags
+    buf[1] = (endpoint_id >> 8) as u8;
+    buf[2] = endpoint_id as u8;
+    buf[3] = 0x04; // data_len = 4 (float32)
+    f32_to_big_endian_bytes(value, &mut buf, 4);
+    buf
+}
+
+/// Decode a PARAM_READ response value (float32 BE).
+/// Returns `None` if the frame is not a valid read response.
+pub fn decode_param_read_response(data: &[u8], expected_endpoint_id: u16) -> Option<f32> {
+    if data.len() < 8 {
+        return None;
+    }
+    let endpoint_id = ((data[1] as u16) << 8) | (data[2] as u16);
+    if endpoint_id != expected_endpoint_id {
+        return None;
+    }
+    if data[3] != 4 {
+        return None;
+    }
+    Some(big_endian_bytes_to_f32(data, 4))
+}
+
+/// Check if a frame is a PARAM_WRITE acknowledgment (silent confirmation).
+pub fn is_param_write_ack(data: &[u8], expected_endpoint_id: u16) -> bool {
+    if data.len() < 8 {
+        return false;
+    }
+    let endpoint_id = ((data[1] as u16) << 8) | (data[2] as u16);
+    endpoint_id == expected_endpoint_id && data[3] == 0
+}
+
+/// Encode a CONFIG_SAVE request (empty frame).
+pub fn encode_config_save() -> [u8; 8] {
+    [0u8; 8]
+}
+
+/// Encode a CONFIG_RESET request (empty frame).
+pub fn encode_config_reset() -> [u8; 8] {
+    [0u8; 8]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_big_endian_float_roundtrip() {
+        let mut buf = [0u8; 8];
+        f32_to_big_endian_bytes(3.14, &mut buf, 0);
+        let val = big_endian_bytes_to_f32(&buf, 0);
+        assert!((val - 3.14).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_big_endian_float_zero() {
+        let mut buf = [0u8; 8];
+        f32_to_big_endian_bytes(0.0, &mut buf, 0);
+        assert_eq!(buf[0], 0);
+        assert_eq!(buf[1], 0);
+        assert_eq!(buf[2], 0);
+        assert_eq!(buf[3], 0);
+    }
+
+    #[test]
+    fn test_encode_param_read() {
+        let data = encode_param_read(0x001C);
+        assert_eq!(data[0], 0x00); // flags
+        assert_eq!(data[1], 0x00); // endpoint_id high
+        assert_eq!(data[2], 0x1C); // endpoint_id low
+        assert_eq!(data[3], 0x00); // data_len = 0
+    }
+
+    #[test]
+    fn test_encode_param_write() {
+        let data = encode_param_write(0x0035, 50.0);
+        assert_eq!(data[0], 0x00); // flags
+        assert_eq!(data[1], 0x00); // endpoint_id high
+        assert_eq!(data[2], 0x35); // endpoint_id low
+        assert_eq!(data[3], 0x04); // data_len = 4
+    }
+
+    #[test]
+    fn test_decode_param_read_response() {
+        // Create a valid read response: endpoint 0x001C, value 10.0
+        let mut data = [0u8; 8];
+        data[0] = 0x00;
+        data[1] = 0x00;
+        data[2] = 0x1C;
+        data[3] = 0x04;
+        f32_to_big_endian_bytes(10.0, &mut data, 4);
+
+        let val = decode_param_read_response(&data, 0x001C);
+        assert!(val.is_some());
+        assert!((val.unwrap() - 10.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_decode_param_read_response_wrong_endpoint() {
+        let mut data = [0u8; 8];
+        data[3] = 0x04;
+        let val = decode_param_read_response(&data, 0x001C);
+        assert!(val.is_none());
+    }
+
+    #[test]
+    fn test_is_param_write_ack() {
+        let mut data = [0u8; 8];
+        data[1] = 0x00;
+        data[2] = 0x35;
+        data[3] = 0x00; // data_len = 0 → ack
+        assert!(is_param_write_ack(&data, 0x0035));
+        assert!(!is_param_write_ack(&data, 0x0036));
+    }
+
+    #[test]
+    fn test_pack_unpack_mit_zero_values() {
+        let params = MitCommandParams::default();
+        let packed = pack_mit_command(&params, 12.5, 50.0, 500.0, 100.0, 10.0);
+        // Zero pos → mid-range uint16 (0x8000), zero vel/kp/kd/torque → mid-range
+        assert_eq!(packed[0], 0x80);
+        assert_eq!(packed[1], 0x00);
+    }
+
+    #[test]
+    fn test_can_id_boundary_values() {
+        // Minimum values
+        let id = make_can_id(0, 0, 0, 0, 0);
+        assert_eq!(id, 0);
+
+        // Maximum values
+        let id = make_can_id(7, 0xFF, 0xFF, 0xFF, 3);
+        let parts = can_id_parts(id);
+        assert_eq!(parts.priority, 7);
+        assert_eq!(parts.msg_type, 0xFF);
+        assert_eq!(parts.dest, 0xFF);
+        assert_eq!(parts.source, 0xFF);
+        assert_eq!(parts.seq, 3);
+        assert!(parts.is_broadcast); // 0xFF >= 0x80
+    }
+}

--- a/motor_vendors/cyberbeast/src/registers.rs
+++ b/motor_vendors/cyberbeast/src/registers.rs
@@ -1,0 +1,139 @@
+//! CyberBeast register table.
+//!
+//! The CyberBeast protocol uses ODrive's SDO endpoint system for parameter
+//! access (via `MSG_PARAM_READ` / `MSG_PARAM_WRITE` with 16-bit endpoint IDs).
+//! This is different from traditional fixed-register protocols like Damiao or
+//! RobStride — the full parameter map is discovered at runtime via
+//! `MSG_JSON_DESC_READ` (endpoint descriptor JSON).
+//!
+//! This module provides a minimal static table of commonly-used endpoint IDs
+//! for documentation and tooling. For complete parameter access, use the
+//! dynamic JSON descriptor mechanism.
+
+#[derive(Debug, Clone, Copy)]
+pub struct RegisterInfo {
+    /// SDO endpoint ID (16-bit).
+    pub endpoint_id: u16,
+    /// Human-readable variable name.
+    pub variable: &'static str,
+    /// Description.
+    pub description: &'static str,
+}
+
+/// Commonly-used ODrive endpoint IDs for CyberBeast protocol.
+///
+/// These are the most frequently accessed parameters. The full endpoint map
+/// (hundreds of entries) is obtained at runtime via `MSG_JSON_DESC_READ`.
+pub static REGISTER_TABLE: &[RegisterInfo] = &[
+    // ── Axis state ──
+    RegisterInfo {
+        endpoint_id: 0x0001,
+        variable: "axis.requested_state",
+        description: "Requested axis state (AXIS_STATE_*)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0012,
+        variable: "axis.error",
+        description: "Axis error flags",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0000,
+        variable: "axis.current_state",
+        description: "Current axis state",
+    },
+    // ── Motor ──
+    RegisterInfo {
+        endpoint_id: 0x0019,
+        variable: "motor.config.torque_constant",
+        description: "Motor torque constant (Nm/A)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x001D,
+        variable: "motor.error",
+        description: "Motor error flags",
+    },
+    RegisterInfo {
+        endpoint_id: 0x001C,
+        variable: "motor.config.current_lim",
+        description: "Motor current limit (A)",
+    },
+    // ── Encoder ──
+    RegisterInfo {
+        endpoint_id: 0x002C,
+        variable: "encoder.error",
+        description: "Encoder error flags",
+    },
+    // ── Controller ──
+    RegisterInfo {
+        endpoint_id: 0x0030,
+        variable: "controller.config.control_mode",
+        description: "Control mode (POSITION/VELOCITY/TORQUE)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0031,
+        variable: "controller.config.input_mode",
+        description: "Input mode (PASSTHROUGH/POS_FILTER/VEL_RAMP/TORQUE_RAMP/MIT)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0035,
+        variable: "controller.config.pos_gain",
+        description: "Position gain (turns/s per turn)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0036,
+        variable: "controller.config.vel_gain",
+        description: "Velocity gain (Nm per turn/s)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0037,
+        variable: "controller.config.vel_integrator_gain",
+        description: "Velocity integrator gain (Nm per turn)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0039,
+        variable: "controller.config.vel_limit",
+        description: "Velocity limit (turns/s)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x003D,
+        variable: "controller.error",
+        description: "Controller error flags",
+    },
+    // ── MIT limits ──
+    RegisterInfo {
+        endpoint_id: 0x0300,
+        variable: "controller.config.mit_max_pos",
+        description: "MIT max position (rad)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0301,
+        variable: "controller.config.mit_max_vel",
+        description: "MIT max velocity (rad/s)",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0302,
+        variable: "controller.config.mit_max_kp",
+        description: "MIT max Kp",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0303,
+        variable: "controller.config.mit_max_kd",
+        description: "MIT max Kd",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0304,
+        variable: "controller.config.mit_max_torque",
+        description: "MIT max torque (Nm)",
+    },
+    // ── CAN config ──
+    RegisterInfo {
+        endpoint_id: 0x0100,
+        variable: "can.config.node_id",
+        description: "CAN node ID",
+    },
+    RegisterInfo {
+        endpoint_id: 0x0101,
+        variable: "can.config.break_timeout",
+        description: "CAN break timeout (ms, 0 = default 100ms)",
+    },
+];

--- a/tools/fix_cyberbeast_ws.py
+++ b/tools/fix_cyberbeast_ws.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Add CyberBeast catch-all arms to all match exhaustion points in ws_gateway."""
+import re, subprocess, sys
+
+ws_root = "integrations/ws_gateway/src"
+
+# Run cargo check to find all error locations
+r = subprocess.run(["cargo", "check", "-p", "ws_gateway"], capture_output=True, text=True, cwd=".")
+files_with_errors = set()
+for line in r.stderr.splitlines():
+    m = re.search(r'integrations/ws_gateway/src/(\S+\.rs):(\d+)', line)
+    if m and "non-exhaustive" in r.stderr:
+        files_with_errors.add(ws_root + "/" + m.group(1))
+
+print(f"Files with match exhaustion errors: {len(files_with_errors)}")
+for f in sorted(files_with_errors):
+    print(f"  {f}")

--- a/tools/fix_cyberbeast_ws2.py
+++ b/tools/fix_cyberbeast_ws2.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Fix all match exhaustion errors in ws_gateway by adding CyberBeast arms."""
+import re, sys
+
+fixes = {
+    # connection.rs
+    "integrations/ws_gateway/src/router/handlers/connection.rs": [
+        # enable: after Robstride arm (line 234), before None
+        (r"(Some\(MotorHandle::Robstride\(m\)\) => m\.enable\(\)\.map_err\(\|e\| e\.to_string\(\)\)\?\s*,\s*\n\s*None)", 
+         r"Some(MotorHandle::CyberBeast(m)) => m.enable().map_err(|e| e.to_string())?,\n        \1"),
+        # disable: after Robstride arm
+        (r"(Some\(MotorHandle::Robstride\(m\)\) => m\.disable\(\)\.map_err\(\|e\| e\.to_string\(\)\)\?\s*,\s*\n\s*None)",
+         r"Some(MotorHandle::CyberBeast(m)) => m.disable().map_err(|e| e.to_string())?,\n        \1"),
+        # stop_active: after Robstride arm 
+        (r"(MotorHandle::Robstride\(mm\) => mm\.set_velocity_target\(0\.0\)\.map_err\(\|e\| e\.to_string\(\)\)\?\s*,\s*\n\s*None)",
+         r"MotorHandle::CyberBeast(mm) => mm.send_stop_motor().map_err(|e| e.to_string())?,\n            \1"),
+        # vendor detection: after Robstride arm
+        (r"(Some\(MotorHandle::Robstride\(_\)\) => Vendor::Robstride\s*,)",
+         r"Some(MotorHandle::CyberBeast(_)) => Vendor::CyberBeast,\n        \1"),
+        # vendor matching pair: after Robstride pair
+        (r"(\| \(Some\(ControllerHandle::Robstride\(_\)\), Some\(MotorHandle::Robstride\(_\)\)\)\s*=> \{\})",
+         r"\1\n        | (Some(ControllerHandle::CyberBeast(_)), Some(MotorHandle::CyberBeast(_))) => {}"),
+        # enable_all: after Robstride
+        (r"(ControllerHandle::Robstride\(ctrl\) => \{\s*\n\s*ctrl\.enable_all)",
+         r"ControllerHandle::CyberBeast(ctrl) => {\n                ctrl.enable_all"),
+        # shutdown: after Robstride
+        (r"(ControllerHandle::Robstride\(ctrl\) => ctrl\.shutdown\(\)\.map_err\(\|e\| e\.to_string\(\)\)\?\s*,)",
+         r"ControllerHandle::CyberBeast(ctrl) => ctrl.shutdown().map_err(|e| e.to_string())?,\n            \1"),
+    ],
+    # control.rs  
+    "integrations/ws_gateway/src/router/handlers/control.rs": [],
+    # register.rs
+    "integrations/ws_gateway/src/router/handlers/register.rs": [],
+    # runtime.rs
+    "integrations/ws_gateway/src/session/runtime.rs": [],
+}
+
+# For simpler approach - just add catch-all CyberBeast arms
+# to all match blocks that lack them
+files_with_matches = {
+    "integrations/ws_gateway/src/router/handlers/connection.rs": [
+        # Each entry: (line_before, arm_to_add)
+    ],
+}
+
+print("Skipping complex pattern-based approach, will use manual edits.")
+print("Key files to fix:")
+for f in fixes:
+    print(f"  {f}")


### PR DESCRIPTION
## Summary

Add a new vendor crate `motor_vendors/cyberbeast` implementing the CyberBeast CAN FD protocol from ODrive firmware. The protocol uses 29-bit extended CAN IDs with J1939-inspired layout (3-bit priority, 8-bit MsgType, implicit point-to-point/broadcast addressing, and 2-bit sequence numbers).

## Changes

New crate structure (follows the standard 4-module vendor template):
- protocol.rs: CAN ID encode/decode, Big-Endian float32 helpers, MIT command pack/unpack (compact 8-byte bit-packed encoding), MIT response decode, heartbeat/query response decoders
- registers.rs: static table of commonly-used ODrive SDO endpoint IDs for documentation and tooling
- motor.rs: CyberBeastMotor struct with MotorDevice trait impl, model catalog (odrive-default/pro/high-torque/high-speed), command methods (MIT/POS/VEL/TORQUE/CURRENT control, start/stop, set-zero, clear-errors, estop), feedback frame processing
- controller.rs: CyberBeastController facade over VendorController

Workspace: register `motor_vendors/cyberbeast` in root Cargo.toml.

## Validation

- [x] `cargo check`
- [x] `cargo test`
- [x] Docs updated if needed

## Notes

- 
