### PR TITLE
fix(ws): make RobStride stop mode-aware

### DIFF
--- a/integrations/ws_gateway/PROTOCOL.zh-CN.md
+++ b/integrations/ws_gateway/PROTOCOL.zh-CN.md
@@ -363,14 +363,15 @@ RobStride：
 
 ### 8.5 `stop`
 
-作用：停止 continuous active 命令，并发送厂商对应的停止/零速度命令。
+作用：停止 continuous active 命令，并发送厂商对应的受控停止命令。`stop`
+与 `disable` 语义不同：前者尽量保留闭环控制/保持力矩，后者取消电机力矩。
 
 厂商行为：
 
 | 厂商 | 行为 |
 | --- | --- |
 | Damiao | `send_cmd_vel(0.0)` |
-| RobStride | `set_velocity_target(0.0)` |
+| RobStride | 按实时读取的 `run_mode` 选择：MIT 保持当前位置（沿用最近一次 `kp/kd`）、PP 写 `vel_max=0`、Velocity 写 `spd_ref=0`、CSP 将 `loc_ref` 写为当前位置 |
 | Hexfellow | 发送零 MIT |
 | MyActuator | `stop_motor()` |
 | HighTorque | 发送 stop raw frame |
@@ -384,8 +385,13 @@ RobStride：
 返回：
 
 ```json
-{"stopped":true}
+{"stopped":true,"stop_requested":true,"motion_confirmed":false}
 ```
+
+`stopped` 是为兼容旧客户端保留的命令接受字段，不代表网关已经测得速度为零。
+新客户端应读取 `stop_requested` 和 `motion_confirmed`。RobStride 还返回
+`mode`、`strategy` 与 `torque_off:false`。如果 MIT 会话没有可靠的最近一次
+`kp/kd`，网关会返回错误，而不会猜测可能不安全的保持增益。
 
 ### 8.6 `state_once`
 

--- a/integrations/ws_gateway/README.md
+++ b/integrations/ws_gateway/README.md
@@ -333,7 +333,10 @@ RobStride parameter stream frame:
 - `--vendor damiao|robstride|hexfellow|myactuator|hightorque` controls default target vendor.
 - `set_target` can switch vendor/transport/channel/serial/model/id on the fly per session.
 - `continuous=true` keeps sending that control command every tick.
-- `stop` clears continuous control.
+- `stop` clears continuous control and requests a vendor-aware controlled stop.
+  For RobStride it reads `run_mode`, keeps torque enabled, and uses zero
+  `spd_ref` (Velocity), zero `vel_max` (PP), or a current-position hold
+  (CSP/MIT). `disable` remains the separate torque-off operation.
 - `set_id` is vendor-aware:
   - Damiao: write `MST_ID` first, then `ESC_ID`.
   - RobStride: device ID update via `SET_DEVICE_ID`.

--- a/integrations/ws_gateway/README.zh-CN.md
+++ b/integrations/ws_gateway/README.zh-CN.md
@@ -332,7 +332,9 @@ or offline joints return `has_value:false` instead of failing the whole request.
 - `--vendor damiao|robstride|hexfellow|myactuator|hightorque` 用于设置会话默认厂商。
 - `set_target` 可在单个会话中动态切换厂商/transport/通道/串口/型号/ID。
 - `continuous=true` 会在每个 tick 持续发送该控制命令。
-- `stop` 用于清除持续控制。
+- `stop` 用于清除持续控制并请求厂商感知的受控停车。RobStride 会读取
+  `run_mode`，保持电机使能，并按模式使用零 `spd_ref`（Velocity）、零
+  `vel_max`（PP）或当前位置保持（CSP/MIT）；`disable` 仍是独立的失能操作。
 - `set_id` 按厂商处理：
   - Damiao：先写 `MST_ID`，再写 `ESC_ID`。
   - RobStride：使用 `SET_DEVICE_ID` 更新设备 ID。

--- a/integrations/ws_gateway/src/router/handlers/connection.rs
+++ b/integrations/ws_gateway/src/router/handlers/connection.rs
@@ -19,7 +19,7 @@ pub(crate) fn handle(
         "set_target" => Some(handle_set_target(v, ctx)),
         "enable" => Some(handle_enable(v, ctx)),
         "disable" => Some(handle_disable(v, ctx)),
-        "stop" => Some(handle_stop(ctx)),
+        "stop" => Some(handle_stop(v, ctx)),
         "state_once" => Some(handle_state_once(ctx)),
         "damiao_state_many" => Some(handle_damiao_state_many(v, ctx)),
         "state_stream" => Some(handle_state_stream(v, state_stream_enabled)),
@@ -260,11 +260,23 @@ fn handle_disable(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         None => return Err("motor not connected".to_string()),
     }
     ctx.active = None;
+    ctx.robstride_mit_gains = None;
     Ok(json!({"disabled": true}))
 }
 
-fn handle_stop(ctx: &mut SessionCtx) -> Result<Value, String> {
-    ctx.active = None;
+fn handle_stop(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
+    ctx.retarget_from_request_if_present(
+        v.get("vendor")
+            .and_then(Value::as_str)
+            .map(crate::model::Vendor::from_str)
+            .transpose()?,
+        v.get("model").and_then(Value::as_str),
+        v.get("motor_id")
+            .map(|_| as_u16(v, "motor_id", ctx.target.motor_id)),
+        v.get("feedback_id")
+            .map(|_| as_u16(v, "feedback_id", ctx.target.feedback_id)),
+    )?;
+    ctx.ensure_connected()?;
     if let Some(m) = ctx.motor.as_ref() {
         match m {
             MotorHandle::Damiao(mm) => mm.send_cmd_vel(0.0).map_err(|e| e.to_string())?,
@@ -291,10 +303,38 @@ fn handle_stop(ctx: &mut SessionCtx) -> Result<Value, String> {
                 }
             }
             MotorHandle::Myactuator(mm) => mm.stop_motor().map_err(|e| e.to_string())?,
-            MotorHandle::Robstride(mm) => mm.set_velocity_target(0.0).map_err(|e| e.to_string())?,
+            MotorHandle::Robstride(mm) => {
+                // Resolve the live run_mode before clearing session state. One-shot
+                // commands are not stored in `active`, and the mode may also have
+                // been changed through the parameter API.
+                let mode_result = mm.controlled_stop(
+                    ctx.robstride_mit_gains,
+                    std::time::Duration::from_millis(300),
+                );
+                ctx.active = None;
+                let mode = mode_result.map_err(|e| e.to_string())?;
+                return Ok(json!({
+                    "stopped": true,
+                    "stop_requested": true,
+                    "motion_confirmed": false,
+                    "torque_off": false,
+                    "mode": mode.as_str(),
+                    "strategy": match mode {
+                        motor_vendor_robstride::ControlMode::Mit => "hold-current-position-mit",
+                        motor_vendor_robstride::ControlMode::Position => "pp-vel-max-zero",
+                        motor_vendor_robstride::ControlMode::Velocity => "velocity-target-zero",
+                        motor_vendor_robstride::ControlMode::PositionCsp => "hold-current-position-csp",
+                    }
+                }));
+            }
         }
     }
-    Ok(json!({"stopped": true}))
+    ctx.active = None;
+    Ok(json!({
+        "stopped": true,
+        "stop_requested": true,
+        "motion_confirmed": false
+    }))
 }
 
 fn handle_state_once(ctx: &mut SessionCtx) -> Result<Value, String> {

--- a/integrations/ws_gateway/src/router/handlers/control.rs
+++ b/integrations/ws_gateway/src/router/handlers/control.rs
@@ -68,6 +68,7 @@ fn handle_mit(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
             {
                 m.send_cmd_mit(pos, vel, kp, kd, tau)
                     .map_err(|e| e.to_string())?;
+                ctx.robstride_mit_gains = Some((kp, kd));
             }
         }
         Some(MotorHandle::Hexfellow(m)) => {
@@ -189,6 +190,7 @@ fn handle_pos_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
                 m.write_parameter(0x7016, RobstrideParameterValue::F32(pos))
                     .map_err(|e| e.to_string())?;
             }
+            ctx.robstride_mit_gains = None;
             ctx.active = if as_bool(v, "continuous", false) {
                 Some(cmd)
             } else {
@@ -245,6 +247,7 @@ fn handle_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
             if let ActiveCommand::Vel { vel } = cmd {
                 m.set_velocity_target(vel).map_err(|e| e.to_string())?;
             }
+            ctx.robstride_mit_gains = None;
         }
         Some(MotorHandle::Myactuator(m)) => {
             if let ActiveCommand::Vel { vel } = cmd {

--- a/integrations/ws_gateway/src/router/handlers/register.rs
+++ b/integrations/ws_gateway/src/router/handlers/register.rs
@@ -6,7 +6,9 @@ use crate::model::{ControllerHandle, MotorHandle};
 use crate::session::SessionCtx;
 use crate::vendors::damiao_ws::ensure_control_mode_soft;
 use crate::vendors::hightorque_ws::send_hightorque_ext;
-use motor_vendor_robstride::ParameterValue as RobstrideParameterValue;
+use motor_vendor_robstride::{
+    ParameterId as RobstrideParameterId, ParameterValue as RobstrideParameterValue,
+};
 use serde_json::{json, Value};
 use std::time::Duration;
 
@@ -485,12 +487,19 @@ fn handle_robstride_read_param_op(v: &Value, ctx: &mut SessionCtx) -> Result<Val
 
 fn handle_robstride_write_param_op(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
     ctx.ensure_connected()?;
-    match ctx.motor.as_ref() {
+    let run_mode_changed = as_u16(v, "param_id", 0x700A) == RobstrideParameterId::Mode as u16;
+    let result = match ctx.motor.as_ref() {
         Some(MotorHandle::Robstride(m)) => handle_robstride_write_param(m, v),
         Some(MotorHandle::Damiao(_)) => {
             Err("robstride_write_param requires vendor=robstride".to_string())
         }
         Some(_) => Err("robstride_write_param requires vendor=robstride".to_string()),
         None => Err("motor not connected".to_string()),
+    };
+    if result.is_ok() && run_mode_changed {
+        // Raw run_mode writes bypass the typed control handlers, so any MIT
+        // gains remembered by this gateway session can no longer be trusted.
+        ctx.robstride_mit_gains = None;
     }
+    result
 }

--- a/integrations/ws_gateway/src/session/connect.rs
+++ b/integrations/ws_gateway/src/session/connect.rs
@@ -138,6 +138,7 @@ impl SessionCtx {
 
     pub(crate) fn disconnect(&mut self, shutdown: bool) {
         self.active = None;
+        self.robstride_mit_gains = None;
         self.motor = None;
         if let Some(ctrl) = self.controller.take() {
             match ctrl {

--- a/integrations/ws_gateway/src/session/mod.rs
+++ b/integrations/ws_gateway/src/session/mod.rs
@@ -8,6 +8,7 @@ pub(crate) struct SessionCtx {
     pub(crate) controller: Option<ControllerHandle>,
     pub(crate) motor: Option<MotorHandle>,
     pub(crate) active: Option<ActiveCommand>,
+    pub(crate) robstride_mit_gains: Option<(f32, f32)>,
 }
 
 pub(crate) fn myactuator_feedback_default(motor_id: u16) -> u16 {
@@ -26,6 +27,7 @@ impl SessionCtx {
             controller: None,
             motor: None,
             active: None,
+            robstride_mit_gains: None,
         }
     }
 

--- a/motor_vendors/robstride/src/motor.rs
+++ b/motor_vendors/robstride/src/motor.rs
@@ -77,12 +77,35 @@ pub fn model_limits(model: &str) -> Option<(f32, f32, f32)> {
         .map(|spec| (spec.pmax, spec.vmax, spec.tmax))
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlMode {
     Mit = 0,
     Position = 1,
     Velocity = 2,
     PositionCsp = 5,
+}
+
+impl ControlMode {
+    pub fn from_raw(value: i8) -> Result<Self> {
+        match value {
+            0 => Ok(Self::Mit),
+            1 => Ok(Self::Position),
+            2 => Ok(Self::Velocity),
+            5 => Ok(Self::PositionCsp),
+            _ => Err(MotorError::Protocol(format!(
+                "unsupported RobStride run_mode value {value}"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mit => "mit",
+            Self::Position => "pp",
+            Self::Velocity => "velocity",
+            Self::PositionCsp => "csp",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -475,6 +498,50 @@ impl RobstrideMotor {
         )
     }
 
+    pub fn get_control_mode(&self, timeout: Duration) -> Result<ControlMode> {
+        ControlMode::from_raw(self.get_parameter_i8(ParameterId::Mode as u16, timeout)?)
+    }
+
+    /// Requests a controlled stop without sending the communication-type 4
+    /// torque-off frame used by [`Self::disable`].
+    ///
+    /// PP follows the vendor manual's documented in-profile stop (`vel_max=0`).
+    /// Velocity mode commands zero speed. CSP and MIT hold the measured
+    /// position; MIT requires the gains from the most recent command so this
+    /// method never guesses a potentially unsafe stiffness.
+    pub fn controlled_stop(
+        &self,
+        mit_hold_gains: Option<(f32, f32)>,
+        timeout: Duration,
+    ) -> Result<ControlMode> {
+        let mode = self.get_control_mode(timeout)?;
+        match mode {
+            ControlMode::Velocity => self.set_velocity_target(0.0)?,
+            ControlMode::Position => {
+                self.write_parameter(ParameterId::PpVelocityMax as u16, ParameterValue::F32(0.0))?
+            }
+            ControlMode::PositionCsp => {
+                let position =
+                    self.get_parameter_f32(ParameterId::MechanicalPosition as u16, timeout)?;
+                self.write_parameter(
+                    ParameterId::PositionTarget as u16,
+                    ParameterValue::F32(position),
+                )?;
+            }
+            ControlMode::Mit => {
+                let (kp, kd) = mit_hold_gains.ok_or_else(|| {
+                    MotorError::InvalidArgument(
+                        "controlled MIT stop requires the most recent kp/kd gains".to_string(),
+                    )
+                })?;
+                let position =
+                    self.get_parameter_f32(ParameterId::MechanicalPosition as u16, timeout)?;
+                self.send_cmd_mit(position, 0.0, kp, kd, 0.0)?;
+            }
+        }
+        Ok(mode)
+    }
+
     pub fn write_parameter(&self, param_id: u16, value: ParameterValue) -> Result<()> {
         let raw = encode_parameter_value(param_id, value)?;
         let data = encode_parameter_write(param_id, raw);
@@ -778,6 +845,83 @@ mod tests {
     use motor_core::device::MotorDevice;
     use motor_core::test_support::MockBus;
 
+    fn spawn_parameter_responder(
+        motor: Arc<RobstrideMotor>,
+        bus: Arc<MockBus>,
+        replies: Vec<(u16, ParameterValue)>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let mut sent_cursor = 0;
+            for (param_id, value) in replies {
+                let deadline = Instant::now() + Duration::from_millis(250);
+                loop {
+                    let request_seen = {
+                        let sent = bus.sent.lock().expect("sent frames");
+                        let found = sent
+                            .iter()
+                            .enumerate()
+                            .skip(sent_cursor)
+                            .find(|(_, frame)| {
+                                let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+                                comm_type == CommunicationType::READ_PARAMETER
+                                    && u16::from_le_bytes([frame.data[0], frame.data[1]])
+                                        == param_id
+                            });
+                        if let Some((index, _)) = found {
+                            sent_cursor = index + 1;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if request_seen {
+                        let raw = encode_parameter_value(param_id, value)
+                            .expect("encode parameter reply");
+                        motor
+                            .process_feedback_frame(CanFrame {
+                                arbitration_id: build_ext_id(
+                                    CommunicationType::READ_PARAMETER,
+                                    motor.motor_id,
+                                    motor.feedback_id as u8,
+                                ),
+                                data: encode_parameter_write(param_id, raw),
+                                dlc: 8,
+                                is_extended: true,
+                                is_rx: true,
+                            })
+                            .expect("process parameter reply");
+                        break;
+                    }
+                    assert!(
+                        Instant::now() < deadline,
+                        "parameter read 0x{param_id:04X} was not sent"
+                    );
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+            }
+        })
+    }
+
+    fn parameter_write(sent: &[CanFrame], param_id: u16) -> Option<[u8; 4]> {
+        sent.iter().find_map(|frame| {
+            let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+            if comm_type == CommunicationType::WRITE_PARAMETER
+                && u16::from_le_bytes([frame.data[0], frame.data[1]]) == param_id
+            {
+                Some([frame.data[4], frame.data[5], frame.data[6], frame.data[7]])
+            } else {
+                None
+            }
+        })
+    }
+
+    fn assert_no_torque_off_frame(sent: &[CanFrame]) {
+        assert!(sent.iter().all(|frame| {
+            let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+            comm_type != CommunicationType::DISABLE
+        }));
+    }
+
     #[test]
     fn get_parameter_times_out_when_no_reply_arrives() {
         let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
@@ -858,6 +1002,161 @@ mod tests {
         assert_eq!(sent[0].dlc, 8);
         assert!(sent[0].is_extended);
         assert!(!sent[0].is_rx);
+    }
+
+    #[test]
+    fn controlled_stop_in_pp_writes_vel_max_zero_without_disabling() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let responder = spawn_parameter_responder(
+            Arc::clone(&motor),
+            Arc::clone(&bus),
+            vec![(ParameterId::Mode as u16, ParameterValue::I8(1))],
+        );
+
+        let mode = motor
+            .controlled_stop(None, Duration::from_millis(100))
+            .expect("controlled PP stop");
+        responder.join().expect("parameter responder");
+
+        assert_eq!(mode, ControlMode::Position);
+        let sent = bus.sent.lock().expect("sent frames");
+        assert_eq!(
+            parameter_write(&sent, ParameterId::PpVelocityMax as u16),
+            Some(0.0f32.to_le_bytes())
+        );
+        assert_no_torque_off_frame(&sent);
+    }
+
+    #[test]
+    fn controlled_stop_in_velocity_mode_writes_zero_speed_without_disabling() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let responder = spawn_parameter_responder(
+            Arc::clone(&motor),
+            Arc::clone(&bus),
+            vec![(ParameterId::Mode as u16, ParameterValue::I8(2))],
+        );
+
+        let mode = motor
+            .controlled_stop(None, Duration::from_millis(100))
+            .expect("controlled velocity stop");
+        responder.join().expect("parameter responder");
+
+        assert_eq!(mode, ControlMode::Velocity);
+        let sent = bus.sent.lock().expect("sent frames");
+        assert_eq!(
+            parameter_write(&sent, ParameterId::VelocityTarget as u16),
+            Some(0.0f32.to_le_bytes())
+        );
+        assert_no_torque_off_frame(&sent);
+    }
+
+    #[test]
+    fn controlled_stop_in_csp_holds_measured_position_without_disabling() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let hold_position = 0.42f32;
+        let responder = spawn_parameter_responder(
+            Arc::clone(&motor),
+            Arc::clone(&bus),
+            vec![
+                (ParameterId::Mode as u16, ParameterValue::I8(5)),
+                (
+                    ParameterId::MechanicalPosition as u16,
+                    ParameterValue::F32(hold_position),
+                ),
+            ],
+        );
+
+        let mode = motor
+            .controlled_stop(None, Duration::from_millis(100))
+            .expect("controlled CSP stop");
+        responder.join().expect("parameter responder");
+
+        assert_eq!(mode, ControlMode::PositionCsp);
+        let sent = bus.sent.lock().expect("sent frames");
+        assert_eq!(
+            parameter_write(&sent, ParameterId::PositionTarget as u16),
+            Some(hold_position.to_le_bytes())
+        );
+        assert_no_torque_off_frame(&sent);
+    }
+
+    #[test]
+    fn controlled_stop_in_mit_holds_position_with_supplied_gains() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let hold_position = -0.25f32;
+        let kp = 12.0f32;
+        let kd = 0.5f32;
+        let responder = spawn_parameter_responder(
+            Arc::clone(&motor),
+            Arc::clone(&bus),
+            vec![
+                (ParameterId::Mode as u16, ParameterValue::I8(0)),
+                (
+                    ParameterId::MechanicalPosition as u16,
+                    ParameterValue::F32(hold_position),
+                ),
+            ],
+        );
+
+        let mode = motor
+            .controlled_stop(Some((kp, kd)), Duration::from_millis(100))
+            .expect("controlled MIT stop");
+        responder.join().expect("parameter responder");
+
+        assert_eq!(mode, ControlMode::Mit);
+        let sent = bus.sent.lock().expect("sent frames");
+        let operation_frame = sent
+            .iter()
+            .find(|frame| {
+                let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+                comm_type == CommunicationType::OPERATION_CONTROL
+            })
+            .expect("MIT hold frame");
+        let (expected_extra, expected_data) = encode_mit_command(
+            hold_position,
+            0.0,
+            kp,
+            kd,
+            0.0,
+            motor.limits.p_max,
+            motor.limits.v_max,
+            motor.limits.t_max,
+            motor.kp_max,
+            motor.kd_max,
+        );
+        let (_, actual_extra, _) = ext_id_parts(operation_frame.arbitration_id);
+        assert_eq!(actual_extra, expected_extra);
+        assert_eq!(operation_frame.data, expected_data);
+        assert_no_torque_off_frame(&sent);
+    }
+
+    #[test]
+    fn controlled_stop_in_mit_rejects_unknown_hold_gains() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let responder = spawn_parameter_responder(
+            Arc::clone(&motor),
+            Arc::clone(&bus),
+            vec![(ParameterId::Mode as u16, ParameterValue::I8(0))],
+        );
+
+        let err = motor
+            .controlled_stop(None, Duration::from_millis(100))
+            .expect_err("missing MIT gains should fail");
+        responder.join().expect("parameter responder");
+
+        assert!(err.to_string().contains("most recent kp/kd"));
+        let sent = bus.sent.lock().expect("sent frames");
+        assert_no_torque_off_frame(&sent);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- read the live RobStride `run_mode` before choosing a Stop strategy
- keep Stop torque-on and separate from the communication-type 4 `disable()` path
- stop Velocity with `spd_ref=0`
- stop PP with the manual's planned-stop behavior, `vel_max=0`
- hold the measured current position in CSP
- hold the measured current position in MIT using the last gains sent by this gateway session
- reject MIT Stop when safe hold gains are unknown instead of guessing stiffness
- apply Stop request target fields and ensure a motor connection before reporting success
- retain `stopped: true` for compatibility while adding fields that distinguish command acceptance from confirmed standstill

## Root cause

The gateway previously implemented RobStride Stop with `set_velocity_target(0.0)`. That writes the Velocity-mode `spd_ref`, which PP does not consume, so an in-progress PP move continued toward its original target. The handler could also return `stopped: true` when the session had no motor handle, even though it sent no command.

The mode-specific behavior in this PR follows the RobStride instruction manual:

https://wiki.aifitlab.com/robstride-docs/robstride-00-instruction-manual

## RobStride Stop behavior

| Mode | Strategy |
| --- | --- |
| MIT (`run_mode=0`) | read `mechPos`; send a zero-velocity/zero-torque MIT hold with the last `kp`/`kd` |
| PP (`run_mode=1`) | write `0x7024 vel_max=0` |
| Velocity (`run_mode=2`) | write `0x700A spd_ref=0` |
| CSP (`run_mode=5`) | read `0x7019 mechPos`; write it to `0x7016 loc_ref` |

Raw `run_mode` writes invalidate the cached MIT gains. Disconnect, Disable, and non-MIT typed commands clear them as well.

The RobStride response now includes:

```json
{
  "stopped": true,
  "stop_requested": true,
  "motion_confirmed": false,
  "torque_off": false,
  "mode": "pp",
  "strategy": "pp-vel-max-zero"
}
```

`stopped` is retained for existing clients. `motion_confirmed: false` makes clear that the gateway has accepted/sent the request but has not yet measured zero velocity.

## Safety

This PR intentionally does not implement Stop by calling `disable()`. Disable remains the explicit torque-off action because removing torque from a gravity-loaded joint can allow the arm to drop.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- five focused RobStride tests cover PP, Velocity, CSP, MIT hold, unknown MIT gains, and assert that no communication-type 4 torque-off frame is sent

On Windows the commands were run with the installed stable GNU-host toolchain (`+stable-x86_64-pc-windows-gnu`) because MSVC Build Tools were not present.

## Hardware validation

Validated on Windows with MotorBridge 0.5.0, a Seeed reBot B601-RS, RobStride J1 (`motor_id=0x01`, host/master ID `0xFD`), PCAN exposed as `can0`, and the physical power switch immediately available.

- each Stop trial commanded at most `0.020 rad` at `vel_max=0.005 rad/s` and `acc_set=0.05 rad/s²`
- all 3/3 PP Stop trials stopped near `0.0042 rad` instead of continuing to the approximately `0.019 rad` target
- the two extended trials remained within a `0.00043 rad` position range over their final eight samples in a three-second observation window
- every Stop response reported `mode=pp`, `strategy=pp-vel-max-zero`, `torque_off=false`, and `motion_confirmed=false`
- feedback after Stop reported `status_name=ENABLED`; no Disable command was sent during the Stop trials
- a separate J1 Disable check reported `DISABLED`, then returned to `ENABLED` after an explicit Enable, with `0.00055 rad` measured position change

Only J1 was moved. No IDs, zero offsets, calibration, persistent protocol, or stored parameters were changed.