### PR TITLE
feat(ws): expose explicit RobStride PP and CSP position modes

### DIFF
--- a/integrations/ws_gateway/Cargo.toml
+++ b/integrations/ws_gateway/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync"] }
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
+
+[dev-dependencies]
+motor_core = { path = "../../motor_core", features = ["test-support"] }

--- a/integrations/ws_gateway/PROTOCOL.zh-CN.md
+++ b/integrations/ws_gateway/PROTOCOL.zh-CN.md
@@ -696,7 +696,7 @@ Damiao 周期推送：
 | 厂商 | 支持 | 说明 |
 | --- | --- | --- |
 | Damiao | 是 | 原生 POS_VEL |
-| RobStride | 是 | 切 Position mode，写 `0x7017 limit_spd`、`0x701E loc_kp`、`0x7016 loc_ref` |
+| RobStride | 是（兼容路径） | PP：写 `0x7024 vel_max`、可选 `0x7025 acc_set`、`0x701E loc_kp`、`0x7016 loc_ref`；推荐使用显式 PP/CSP op |
 | Hexfellow | 是 | 转成 rev / rev/s |
 | HighTorque | 当前 handler 返回不支持 | 后续可扩展 |
 | MyActuator | 当前 handler 返回不支持 | 可用 `pos` 原生 op |
@@ -709,7 +709,7 @@ Damiao 周期推送：
 | `vlim` | f32 | `1.0` | 速度限制，rad/s |
 | `loc_kp` | f32 | 无 | RobStride 位置环 Kp；若无则尝试 `kp` |
 | `kp` | f32 | 无 | RobStride `loc_kp` fallback |
-| `continuous` | bool | `false` | 是否周期发送 |
+| `continuous` | bool | `false` | RobStride 兼容 PP 路径不接受 `true`；周期目标请使用 CSP |
 | `ensure_timeout_ms` | u64 | `1000` | Damiao ensure mode 超时 |
 
 请求：
@@ -721,13 +721,44 @@ Damiao 周期推送：
 RobStride：
 
 ```json
-{"op":"pos_vel","pos":0.5,"vlim":1.0,"loc_kp":2.0,"continuous":true}
+{"op":"pos_vel","pos":0.5,"vlim":1.0,"acc_set":10.0,"loc_kp":2.0}
 ```
 
 返回：
 
 ```json
-{"op":"pos_vel","continuous":true}
+{"op":"pos_vel","continuous":false,"native_mode":"pp","velocity_parameter":"vel_max","warning":"RobStride pos_vel is a legacy PP alias; prefer pos_vel_pp with vel_max and acc_set"}
+```
+
+### 9.2.1 RobStride `pos_vel_pp` / `pos-vel-pp`
+
+作用：按 RobStride 手册执行 PP 位置模式：`run_mode=1`、`vel_max(0x7024)`、
+`acc_set(0x7025)`、`loc_ref(0x7016)`。
+
+| 字段 | 类型 | 默认值 | 作用 |
+| --- | --- | --- | --- |
+| `pos` | f32 | `0.0` | 目标位置，rad |
+| `vel_max` | f32 | `1.0` | PP 最大速度，rad/s；兼容别名 `vlim` |
+| `acc_set` | f32 | `10.0` | PP 加速度，rad/s²；兼容别名 `acc` |
+| `continuous` | bool | `false` | 必须为 `false`；PP 运动中不支持动态改变速度/加速度 |
+
+```json
+{"op":"pos_vel_pp","pos":0.5,"vel_max":0.02,"acc_set":0.05}
+```
+
+### 9.2.2 RobStride `pos_vel_csp` / `pos-vel-csp`
+
+作用：按 RobStride 手册执行 CSP 位置模式：`run_mode=5`、
+`limit_spd(0x7017)`、`loc_ref(0x7016)`。
+
+| 字段 | 类型 | 默认值 | 作用 |
+| --- | --- | --- | --- |
+| `pos` | f32 | `0.0` | 目标位置，rad |
+| `limit_spd` | f32 | `1.0` | CSP 速度限制，rad/s；兼容别名 `vlim` |
+| `continuous` | bool | `false` | 是否周期发送 CSP 目标 |
+
+```json
+{"op":"pos_vel_csp","pos":0.5,"limit_spd":0.02,"continuous":true}
 ```
 
 ### 9.3 `vel`

--- a/integrations/ws_gateway/README.md
+++ b/integrations/ws_gateway/README.md
@@ -56,13 +56,15 @@ Goal: application layer uses one unified operation set first; vendor-specific op
 | `force_pos` | `{"op":"force_pos", ...}` | `pos`, `vlim`, `ratio` |
 
 If a vendor does not support one of these four baseline modes, gateway returns `unsupported`.
+RobStride additionally exposes `pos_vel_pp` (`pos`, `vel_max`, `acc_set`) and
+`pos_vel_csp` (`pos`, `limit_spd`); hyphenated operation aliases are accepted.
 
 ### Vendor Mapping Table (unified mode -> vendor-native)
 
 | Vendor | `mit` | `pos_vel` | `vel` | `force_pos` | Parameter Differences | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | damiao | native MIT | native POS_VEL | native VEL | native FORCE_POS | full parameter match | baseline reference |
-| robstride | native MIT | maps to native Position (`run_mode=1` + `limit_spd` + `loc_ref`) | native Velocity mode | unsupported | `vel` maps to vendor velocity target; `pos_vel` maps to vendor Position | native param read/write via `robstride_*` |
+| robstride | native MIT | legacy alias for PP (`run_mode=1` + `vel_max` + optional `acc_set` + `loc_ref`) | native Velocity mode | unsupported | explicit `pos_vel_pp` uses `vel_max`/`acc_set`; explicit `pos_vel_csp` uses `limit_spd` | native param read/write via `robstride_*` |
 | hexfellow | native MIT | native POS_VEL | unsupported | unsupported | `mit` supports `kp/kd/tau`; no standalone `vel` | CAN-FD path |
 | myactuator | unsupported | Position setpoint flow | native velocity setpoint | unsupported | `pos_vel` via position setpoint; `vel` in baseline set | native strengths: current/position/version/mode-query |
 | hightorque | native MIT (ht_can mapping) | maps to native pos+vel+tqe | native velocity frame | maps to native pos+vel+tqe | `mit/vel` are raw-frame mapped; `kp/kd` accepted but ignored by protocol; `pos_vel/force_pos` map to pos+vel+tqe | current subset: scan/read/mit/vel/pos-vel/force-pos/stop; `enable/disable` accepted as no-op |
@@ -81,7 +83,9 @@ If a vendor does not support one of these four baseline modes, gateway returns `
 
 - `mit`: same unified fields, but vendor scaling differs internally (gateway adapter handles conversion).
   HighTorque detail: `kp/kd` are currently ignored by protocol path.
-- `pos_vel`: only valid where vendor has equivalent mode.
+- `pos_vel`: only valid where vendor has equivalent mode. For RobStride it is a
+  deprecated PP alias; use `pos_vel_pp` or `pos_vel_csp` to make the native
+  mode and parameter semantics explicit.
 - `vel`: sign/scale conversion is vendor-specific internally.
 - `force_pos`: Damiao native; HighTorque maps to pos+vel+tqe; others unsupported.
 
@@ -107,7 +111,7 @@ Recommended: client calls `{"op":"capabilities"}` on connect and adapts UI/flows
       },
       "robstride": {
         "transports": ["auto", "socketcan", "socketcanfd"],
-        "modes": ["mit", "vel"],
+        "modes": ["mit", "pos_vel", "pos_vel_pp", "pos_vel_csp", "vel"],
         "ops_unified": ["scan", "set_id", "enable", "disable", "stop", "state_once", "status", "verify"],
         "ops_vendor_native": ["robstride_ping", "robstride_read_param", "robstride_write_param"]
       },
@@ -247,6 +251,8 @@ cargo run -p motor_cli --release -- --vendor damiao --channel can0@1000000 --mod
 {"op":"set_target","vendor":"robstride","channel":"can0","model":"rs-06","motor_id":127,"feedback_id":255}
 {"op":"mit","pos":0.0,"vel":0.0,"kp":20.0,"kd":1.0,"tau":0.0,"continuous":true}
 {"op":"pos_vel","pos":3.1,"vlim":1.5,"continuous":true}
+{"op":"pos_vel_pp","pos":0.5,"vel_max":0.02,"acc_set":0.05}
+{"op":"pos_vel_csp","pos":0.5,"limit_spd":0.02,"continuous":true}
 {"op":"vel","vel":0.5,"continuous":true}
 {"op":"force_pos","pos":0.8,"vlim":2.0,"ratio":0.3,"continuous":true}
 {"op":"stop"}

--- a/integrations/ws_gateway/README.zh-CN.md
+++ b/integrations/ws_gateway/README.zh-CN.md
@@ -59,13 +59,15 @@ WS API 主链路已实现。
 | `force_pos` | `{"op":"force_pos", ...}` | `pos`, `vlim`, `ratio` |
 
 若某厂商不支持这四种基线模式，网关统一返回 `unsupported`。
+RobStride 另外显式提供 `pos_vel_pp`（`pos`、`vel_max`、`acc_set`）和
+`pos_vel_csp`（`pos`、`limit_spd`），同时接受连字符形式的 op 别名。
 
 ### 厂商映射表（统一模式 -> 厂商原生）
 
 | 厂商 | `mit` | `pos_vel` | `vel` | `force_pos` | 参数差异 | 备注 |
 | --- | --- | --- | --- | --- | --- | --- |
 | damiao | 原生 MIT | 原生 POS_VEL | 原生 VEL | 原生 FORCE_POS | 参数完整对齐 | 基线参考实现 |
-| robstride | 原生 MIT | 映射到原生 Position（`run_mode=1` + `limit_spd` + `loc_ref`） | 原生 Velocity 模式 | 不支持 | `vel` 映射到 vendor velocity target；`pos_vel` 映射到 vendor Position | 参数读写走 `robstride_*` |
+| robstride | 原生 MIT | PP 兼容别名（`run_mode=1` + `vel_max` + 可选 `acc_set` + `loc_ref`） | 原生 Velocity 模式 | 不支持 | 显式 `pos_vel_pp` 使用 `vel_max`/`acc_set`；显式 `pos_vel_csp` 使用 `limit_spd` | 参数读写走 `robstride_*` |
 | hexfellow | 原生 MIT | 原生 POS_VEL | 不支持 | 不支持 | `mit` 支持 `kp/kd/tau`，无独立 `vel` | CAN-FD 链路 |
 | myactuator | 不支持 | Position 设定流程 | 原生速度设定 | 不支持 | `pos_vel` 通过 position setpoint 实现；基线里 `vel` 可用 | 强项是 current/position/version/mode-query |
 | hightorque | 原生 MIT（ht_can 映射） | 映射到原生 pos+vel+tqe | 原生速度帧 | 映射到原生 pos+vel+tqe | `mit/vel` 为原生帧映射；`kp/kd` 保留但协议侧忽略；`pos_vel/force_pos` 映射到 pos+vel+tqe | 当前子集 scan/read/mit/vel/pos-vel/force-pos/stop；`enable/disable` 接受但为 no-op |
@@ -84,7 +86,8 @@ WS API 主链路已实现。
 
 - `mit`：统一字段一致，但各厂商内部缩放/编码不同，由网关适配层处理。
   HighTorque 细节：当前协议路径会忽略 `kp/kd`。
-- `pos_vel`：仅对具备等价模式的厂商可用。
+- `pos_vel`：仅对具备等价模式的厂商可用。对 RobStride，它是已弃用的 PP
+  兼容别名；应使用 `pos_vel_pp` 或 `pos_vel_csp` 明确原生模式和参数语义。
 - `vel`：方向与量纲转换由厂商适配层内部处理。
 - `force_pos`：Damiao 原生支持；HighTorque 映射到 pos+vel+tqe；其他厂商不支持。
 
@@ -110,7 +113,7 @@ WS API 主链路已实现。
       },
       "robstride": {
         "transports": ["auto", "socketcan", "socketcanfd"],
-        "modes": ["mit", "vel"],
+        "modes": ["mit", "pos_vel", "pos_vel_pp", "pos_vel_csp", "vel"],
         "ops_unified": ["scan", "set_id", "enable", "disable", "stop", "state_once", "status", "verify"],
         "ops_vendor_native": ["robstride_ping", "robstride_read_param", "robstride_write_param"]
       },
@@ -250,6 +253,8 @@ cargo run -p motor_cli --release -- --vendor damiao --channel can0@1000000 --mod
 {"op":"set_target","vendor":"robstride","channel":"can0","model":"rs-06","motor_id":127,"feedback_id":255}
 {"op":"mit","pos":0.0,"vel":0.0,"kp":20.0,"kd":1.0,"tau":0.0,"continuous":true}
 {"op":"pos_vel","pos":3.1,"vlim":1.5,"continuous":true}
+{"op":"pos_vel_pp","pos":0.5,"vel_max":0.02,"acc_set":0.05}
+{"op":"pos_vel_csp","pos":0.5,"limit_spd":0.02,"continuous":true}
 {"op":"vel","vel":0.5,"continuous":true}
 {"op":"force_pos","pos":0.8,"vlim":2.0,"ratio":0.3,"continuous":true}
 {"op":"stop"}

--- a/integrations/ws_gateway/src/router/handlers/connection.rs
+++ b/integrations/ws_gateway/src/router/handlers/connection.rs
@@ -78,7 +78,7 @@ fn handle_capabilities(ctx: &SessionCtx) -> Result<Value, String> {
             },
             "robstride": {
                 "transports": ["auto", "socketcan", "socketcanfd"],
-                "modes": ["mit", "pos_vel", "vel"],
+                "modes": ["mit", "pos_vel", "pos_vel_pp", "pos_vel_csp", "vel"],
                 "ops_unified": ["scan", "set_id", "enable", "disable", "stop", "state_once", "status", "verify"],
                 "ops_vendor_native": ["robstride_ping", "robstride_read_param", "robstride_write_param", "set_active_report"]
             },
@@ -547,4 +547,42 @@ fn handle_shutdown(ctx: &mut SessionCtx) -> Result<Value, String> {
 fn handle_close_bus(ctx: &mut SessionCtx) -> Result<Value, String> {
     ctx.disconnect(false);
     Ok(json!({"closed": true}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Target, Transport};
+
+    fn test_ctx() -> SessionCtx {
+        SessionCtx::new(Target {
+            vendor: Vendor::Robstride,
+            transport: Transport::Auto,
+            channel: "can0".to_string(),
+            serial_port: String::new(),
+            serial_baud: 115_200,
+            dm_device_type: String::new(),
+            dm_channel: String::new(),
+            model: "rs-00".to_string(),
+            motor_id: 1,
+            feedback_id: 0xFD,
+        })
+    }
+
+    #[test]
+    fn capabilities_advertise_explicit_robstride_pp_and_csp_only_for_robstride() {
+        let capabilities = handle_capabilities(&test_ctx()).expect("capabilities");
+        let vendors = capabilities["vendors"].as_object().expect("vendors");
+        let robstride_modes = vendors["robstride"]["modes"]
+            .as_array()
+            .expect("RobStride modes");
+        assert!(robstride_modes.iter().any(|mode| mode == "pos_vel_pp"));
+        assert!(robstride_modes.iter().any(|mode| mode == "pos_vel_csp"));
+
+        for vendor in ["damiao", "hexfellow", "myactuator", "hightorque"] {
+            let modes = vendors[vendor]["modes"].as_array().expect("vendor modes");
+            assert!(!modes.iter().any(|mode| mode == "pos_vel_pp"));
+            assert!(!modes.iter().any(|mode| mode == "pos_vel_csp"));
+        }
+    }
 }

--- a/integrations/ws_gateway/src/router/handlers/control.rs
+++ b/integrations/ws_gateway/src/router/handlers/control.rs
@@ -16,12 +16,46 @@ use serde_json::{json, Value};
 use std::time::Duration;
 
 pub(crate) fn handle(op: &str, v: &Value, ctx: &mut SessionCtx) -> Option<Result<Value, String>> {
+    if let Some(mode) = robstride_position_mode_for_op(op) {
+        return Some(handle_robstride_position(v, ctx, mode));
+    }
     match op {
         "mit" => Some(handle_mit(v, ctx)),
         "pos_vel" | "pos-vel" => Some(handle_pos_vel(v, ctx)),
         "vel" => Some(handle_vel(v, ctx)),
         "force_pos" | "force-pos" => Some(handle_force_pos(v, ctx)),
         _ => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RobstridePositionMode {
+    Pp,
+    Csp,
+}
+
+fn robstride_position_mode_for_op(op: &str) -> Option<RobstridePositionMode> {
+    match op {
+        "pos_vel_pp" | "pos-vel-pp" => Some(RobstridePositionMode::Pp),
+        "pos_vel_csp" | "pos-vel-csp" => Some(RobstridePositionMode::Csp),
+        _ => None,
+    }
+}
+
+fn as_f32_alias(v: &Value, primary: &str, alias: &str, default: f32) -> f32 {
+    v.get(primary)
+        .or_else(|| v.get(alias))
+        .and_then(Value::as_f64)
+        .map(|value| value as f32)
+        .unwrap_or(default)
+}
+
+fn positive_finite(value: f32, name: &str) -> Result<f32, String> {
+    let value = value.abs();
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(format!("{name} must be a finite value greater than zero"))
     }
 }
 
@@ -168,11 +202,21 @@ fn handle_pos_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
             Ok(json!({"op":"pos_vel","continuous": as_bool(v, "continuous", false)}))
         }
         Some(MotorHandle::Robstride(m)) => {
+            if as_bool(v, "continuous", false) {
+                return Err(
+                    "RobStride legacy pos_vel uses PP mode and does not support continuous=true; use pos_vel_csp for cyclic targets"
+                        .to_string(),
+                );
+            }
             ensure_robstride_mode(ctx, m, RobstrideControlMode::Position, "pos_vel")?;
             if let ActiveCommand::PosVel { pos, vlim } = cmd {
-                let speed = vlim.abs();
-                if speed.is_finite() && speed > 0.0 {
-                    m.write_parameter(0x7017, RobstrideParameterValue::F32(speed))
+                let speed = positive_finite(vlim, "vlim")?;
+                m.write_parameter(0x7024, RobstrideParameterValue::F32(speed))
+                    .map_err(|e| e.to_string())?;
+                if v.get("acc_set").is_some() || v.get("acc").is_some() {
+                    let acceleration =
+                        positive_finite(as_f32_alias(v, "acc_set", "acc", 10.0), "acc_set")?;
+                    m.write_parameter(0x7025, RobstrideParameterValue::F32(acceleration))
                         .map_err(|e| e.to_string())?;
                 }
                 let loc_kp = v
@@ -189,12 +233,21 @@ fn handle_pos_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
                 m.write_parameter(0x7016, RobstrideParameterValue::F32(pos))
                     .map_err(|e| e.to_string())?;
             }
-            ctx.active = if as_bool(v, "continuous", false) {
-                Some(cmd)
-            } else {
-                None
-            };
-            Ok(json!({"op":"pos_vel","continuous": as_bool(v, "continuous", false)}))
+            ctx.active = None;
+            let mut out = json!({
+                "op": "pos_vel",
+                "continuous": false,
+                "native_mode": "pp",
+                "velocity_parameter": "vel_max"
+            });
+            add_warnings(
+                &mut out,
+                vec![
+                    "RobStride pos_vel is a legacy PP alias; prefer pos_vel_pp with vel_max and acc_set"
+                        .to_string(),
+                ],
+            );
+            Ok(out)
         }
         Some(MotorHandle::Hightorque(_)) => {
             Err("pos_vel is not supported for hightorque".to_string())
@@ -202,6 +255,79 @@ fn handle_pos_vel(v: &Value, ctx: &mut SessionCtx) -> Result<Value, String> {
         Some(MotorHandle::Myactuator(_)) => {
             Err("pos_vel is not supported for myactuator".to_string())
         }
+        None => Err("motor not connected".to_string()),
+    }
+}
+
+fn handle_robstride_position(
+    v: &Value,
+    ctx: &mut SessionCtx,
+    mode: RobstridePositionMode,
+) -> Result<Value, String> {
+    ctx.ensure_connected()?;
+    let pos = as_f32(v, "pos", 0.0);
+    match ctx.motor.as_ref() {
+        Some(MotorHandle::Robstride(motor)) => match mode {
+            RobstridePositionMode::Pp => {
+                if as_bool(v, "continuous", false) {
+                    return Err(
+                        "pos_vel_pp does not support continuous=true; PP speed and acceleration cannot be changed during motion"
+                            .to_string(),
+                    );
+                }
+                let vel_max = positive_finite(as_f32_alias(v, "vel_max", "vlim", 1.0), "vel_max")?;
+                let acc_set = positive_finite(as_f32_alias(v, "acc_set", "acc", 10.0), "acc_set")?;
+                ensure_robstride_mode(ctx, motor, RobstrideControlMode::Position, "pos_vel_pp")?;
+                motor
+                    .send_cmd_pos_vel_pp(pos, vel_max, acc_set)
+                    .map_err(|e| e.to_string())?;
+                ctx.active = None;
+                Ok(json!({
+                    "op": "pos_vel_pp",
+                    "continuous": false,
+                    "native_mode": "pp",
+                    "pos": pos,
+                    "vel_max": vel_max,
+                    "acc_set": acc_set
+                }))
+            }
+            RobstridePositionMode::Csp => {
+                let limit_spd =
+                    positive_finite(as_f32_alias(v, "limit_spd", "vlim", 1.0), "limit_spd")?;
+                ensure_robstride_mode(
+                    ctx,
+                    motor,
+                    RobstrideControlMode::PositionCsp,
+                    "pos_vel_csp",
+                )?;
+                motor
+                    .send_cmd_pos_vel_csp(pos, limit_spd)
+                    .map_err(|e| e.to_string())?;
+                let continuous = as_bool(v, "continuous", false);
+                ctx.active = if continuous {
+                    Some(ActiveCommand::PosVel {
+                        pos,
+                        vlim: limit_spd,
+                    })
+                } else {
+                    None
+                };
+                Ok(json!({
+                    "op": "pos_vel_csp",
+                    "continuous": continuous,
+                    "native_mode": "csp",
+                    "pos": pos,
+                    "limit_spd": limit_spd
+                }))
+            }
+        },
+        Some(_) => Err(format!(
+            "{} is only supported for robstride",
+            match mode {
+                RobstridePositionMode::Pp => "pos_vel_pp",
+                RobstridePositionMode::Csp => "pos_vel_csp",
+            }
+        )),
         None => Err("motor not connected".to_string()),
     }
 }
@@ -331,5 +457,222 @@ fn add_warnings(out: &mut Value, warnings: Vec<String>) {
     if let Some(obj) = out.as_object_mut() {
         obj.insert("warning".to_string(), json!(warnings[0]));
         obj.insert("warnings".to_string(), json!(warnings));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Target, Transport, Vendor};
+    use motor_core::bus::{CanBus, CanFrame};
+    use motor_core::device::MotorDevice;
+    use motor_core::test_support::MockBus;
+    use motor_vendor_robstride::protocol::build_ext_id;
+    use motor_vendor_robstride::{
+        ext_id_parts, CommunicationType, ParameterId, RobstrideController, RobstrideMotor,
+    };
+    use std::sync::Arc;
+
+    fn robstride_ctx() -> (SessionCtx, Arc<RobstrideMotor>, Arc<MockBus>) {
+        let bus = Arc::new(MockBus::new());
+        let can_bus: Arc<dyn CanBus> = bus.clone();
+        let controller = RobstrideController::new(can_bus);
+        let motor = controller
+            .add_motor(2, 0xFD, "rs-00")
+            .expect("add RobStride motor");
+        let mut ctx = SessionCtx::new(Target {
+            vendor: Vendor::Robstride,
+            transport: Transport::Auto,
+            channel: "test".to_string(),
+            serial_port: String::new(),
+            serial_baud: 115_200,
+            dm_device_type: String::new(),
+            dm_channel: String::new(),
+            model: "rs-00".to_string(),
+            motor_id: 2,
+            feedback_id: 0xFD,
+        });
+        ctx.controller = Some(ControllerHandle::Robstride(controller));
+        ctx.motor = Some(MotorHandle::Robstride(Arc::clone(&motor)));
+        (ctx, motor, bus)
+    }
+
+    fn spawn_mode_and_enable_responder(
+        motor: Arc<RobstrideMotor>,
+        bus: Arc<MockBus>,
+        mode: i8,
+        expected_enables: usize,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            let mut cursor = 0;
+            let mut mode_replied = false;
+            let mut enable_replies = 0;
+            while !mode_replied || enable_replies < expected_enables {
+                let frames = {
+                    let sent = bus.sent.lock().expect("sent frames");
+                    sent.iter().skip(cursor).copied().collect::<Vec<_>>()
+                };
+                cursor += frames.len();
+                for frame in frames {
+                    let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+                    if comm_type == CommunicationType::READ_PARAMETER
+                        && u16::from_le_bytes([frame.data[0], frame.data[1]])
+                            == ParameterId::Mode as u16
+                    {
+                        let mut data = [0u8; 8];
+                        data[0..2].copy_from_slice(&(ParameterId::Mode as u16).to_le_bytes());
+                        data[4] = mode as u8;
+                        motor
+                            .process_feedback_frame(CanFrame {
+                                arbitration_id: build_ext_id(
+                                    CommunicationType::READ_PARAMETER,
+                                    2,
+                                    0xFD,
+                                ),
+                                data,
+                                dlc: 8,
+                                is_extended: true,
+                                is_rx: true,
+                            })
+                            .expect("process mode response");
+                        mode_replied = true;
+                    } else if comm_type == CommunicationType::ENABLE {
+                        motor
+                            .process_feedback_frame(CanFrame {
+                                arbitration_id: build_ext_id(
+                                    CommunicationType::OPERATION_STATUS,
+                                    2,
+                                    0xFD,
+                                ),
+                                data: [0u8; 8],
+                                dlc: 8,
+                                is_extended: true,
+                                is_rx: true,
+                            })
+                            .expect("process enable response");
+                        enable_replies += 1;
+                    }
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for routed command frames"
+                );
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    }
+
+    fn written_parameter_ids(bus: &MockBus) -> Vec<u16> {
+        bus.sent
+            .lock()
+            .expect("sent frames")
+            .iter()
+            .filter_map(|frame| {
+                let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+                (comm_type == CommunicationType::WRITE_PARAMETER)
+                    .then(|| u16::from_le_bytes([frame.data[0], frame.data[1]]))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn routes_robstride_pp_and_csp_operation_aliases() {
+        assert_eq!(
+            robstride_position_mode_for_op("pos_vel_pp"),
+            Some(RobstridePositionMode::Pp)
+        );
+        assert_eq!(
+            robstride_position_mode_for_op("pos-vel-pp"),
+            Some(RobstridePositionMode::Pp)
+        );
+        assert_eq!(
+            robstride_position_mode_for_op("pos_vel_csp"),
+            Some(RobstridePositionMode::Csp)
+        );
+        assert_eq!(
+            robstride_position_mode_for_op("pos-vel-csp"),
+            Some(RobstridePositionMode::Csp)
+        );
+        assert_eq!(robstride_position_mode_for_op("pos_vel"), None);
+    }
+
+    #[test]
+    fn parses_native_parameter_names_and_legacy_aliases() {
+        let native = json!({"vel_max": 0.02, "acc_set": 0.05, "limit_spd": 0.03});
+        assert!((as_f32_alias(&native, "vel_max", "vlim", 1.0) - 0.02).abs() < f32::EPSILON);
+        assert!((as_f32_alias(&native, "acc_set", "acc", 10.0) - 0.05).abs() < f32::EPSILON);
+        assert!((as_f32_alias(&native, "limit_spd", "vlim", 1.0) - 0.03).abs() < f32::EPSILON);
+
+        let aliases = json!({"vlim": 0.04, "acc": 0.06});
+        assert!((as_f32_alias(&aliases, "vel_max", "vlim", 1.0) - 0.04).abs() < f32::EPSILON);
+        assert!((as_f32_alias(&aliases, "acc_set", "acc", 10.0) - 0.06).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn routes_pp_operation_to_pp_parameters() {
+        let (mut ctx, motor, bus) = robstride_ctx();
+        let responder = spawn_mode_and_enable_responder(motor, Arc::clone(&bus), 1, 2);
+
+        let result = handle(
+            "pos_vel_pp",
+            &json!({"pos": 0.02, "vel_max": 0.005, "acc_set": 0.02}),
+            &mut ctx,
+        )
+        .expect("operation routed")
+        .expect("PP operation succeeds");
+        responder.join().expect("responder");
+
+        assert_eq!(result["op"], "pos_vel_pp");
+        let ids = written_parameter_ids(&bus);
+        assert!(ids.contains(&(ParameterId::PpVelocityMax as u16)));
+        assert!(ids.contains(&(ParameterId::PpAccelerationTarget as u16)));
+        assert!(ids.contains(&(ParameterId::PositionTarget as u16)));
+        assert!(!ids.contains(&(ParameterId::VelocityLimit as u16)));
+    }
+
+    #[test]
+    fn legacy_robstride_pos_vel_maps_vlim_to_pp_vel_max() {
+        let (mut ctx, motor, bus) = robstride_ctx();
+        let responder = spawn_mode_and_enable_responder(motor, Arc::clone(&bus), 1, 1);
+
+        let result = handle(
+            "pos_vel",
+            &json!({"pos": 0.02, "vlim": 0.005, "acc": 0.02}),
+            &mut ctx,
+        )
+        .expect("operation routed")
+        .expect("legacy PP operation succeeds");
+        responder.join().expect("responder");
+
+        assert_eq!(result["native_mode"], "pp");
+        assert_eq!(result["velocity_parameter"], "vel_max");
+        let ids = written_parameter_ids(&bus);
+        assert!(ids.contains(&(ParameterId::PpVelocityMax as u16)));
+        assert!(ids.contains(&(ParameterId::PpAccelerationTarget as u16)));
+        assert!(ids.contains(&(ParameterId::PositionTarget as u16)));
+        assert!(!ids.contains(&(ParameterId::VelocityLimit as u16)));
+    }
+
+    #[test]
+    fn routes_csp_operation_to_csp_parameters() {
+        let (mut ctx, motor, bus) = robstride_ctx();
+        let responder = spawn_mode_and_enable_responder(motor, Arc::clone(&bus), 5, 2);
+
+        let result = handle(
+            "pos-vel-csp",
+            &json!({"pos": -0.02, "limit_spd": 0.01}),
+            &mut ctx,
+        )
+        .expect("operation routed")
+        .expect("CSP operation succeeds");
+        responder.join().expect("responder");
+
+        assert_eq!(result["op"], "pos_vel_csp");
+        let ids = written_parameter_ids(&bus);
+        assert!(ids.contains(&(ParameterId::VelocityLimit as u16)));
+        assert!(ids.contains(&(ParameterId::PositionTarget as u16)));
+        assert!(!ids.contains(&(ParameterId::PpVelocityMax as u16)));
+        assert!(!ids.contains(&(ParameterId::PpAccelerationTarget as u16)));
     }
 }

--- a/motor_vendors/robstride/src/motor.rs
+++ b/motor_vendors/robstride/src/motor.rs
@@ -778,6 +778,57 @@ mod tests {
     use motor_core::device::MotorDevice;
     use motor_core::test_support::MockBus;
 
+    fn spawn_enable_responder(
+        motor: Arc<RobstrideMotor>,
+        bus: Arc<MockBus>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_millis(250);
+            loop {
+                let enable_seen = {
+                    let sent = bus.sent.lock().expect("sent frames");
+                    sent.iter().any(|frame| {
+                        let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+                        comm_type == CommunicationType::ENABLE
+                    })
+                };
+                if enable_seen {
+                    motor
+                        .process_feedback_frame(CanFrame {
+                            arbitration_id: build_ext_id(
+                                CommunicationType::OPERATION_STATUS,
+                                motor.motor_id,
+                                motor.feedback_id as u8,
+                            ),
+                            data: [0u8; 8],
+                            dlc: 8,
+                            is_extended: true,
+                            is_rx: true,
+                        })
+                        .expect("process enable acknowledgement");
+                    return;
+                }
+                assert!(Instant::now() < deadline, "enable frame was not sent");
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    }
+
+    fn parameter_writes(sent: &[CanFrame]) -> Vec<(u16, [u8; 4])> {
+        sent.iter()
+            .filter_map(|frame| {
+                let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+                if comm_type != CommunicationType::WRITE_PARAMETER {
+                    return None;
+                }
+                Some((
+                    u16::from_le_bytes([frame.data[0], frame.data[1]]),
+                    [frame.data[4], frame.data[5], frame.data[6], frame.data[7]],
+                ))
+            })
+            .collect()
+    }
+
     #[test]
     fn get_parameter_times_out_when_no_reply_arrives() {
         let bus: Arc<dyn CanBus> = Arc::new(MockBus::new());
@@ -858,6 +909,64 @@ mod tests {
         assert_eq!(sent[0].dlc, 8);
         assert!(sent[0].is_extended);
         assert!(!sent[0].is_rx);
+    }
+
+    #[test]
+    fn pp_position_command_writes_vel_max_acc_set_and_loc_ref() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let responder = spawn_enable_responder(Arc::clone(&motor), Arc::clone(&bus));
+
+        motor
+            .send_cmd_pos_vel_pp(0.25, 0.02, 0.05)
+            .expect("send PP position command");
+        responder.join().expect("enable responder");
+
+        let sent = bus.sent.lock().expect("sent frames");
+        assert_eq!(
+            parameter_writes(&sent),
+            vec![
+                (ParameterId::Mode as u16, [1, 0, 0, 0]),
+                (ParameterId::PpVelocityMax as u16, 0.02f32.to_le_bytes()),
+                (
+                    ParameterId::PpAccelerationTarget as u16,
+                    0.05f32.to_le_bytes()
+                ),
+                (ParameterId::PositionTarget as u16, 0.25f32.to_le_bytes()),
+            ]
+        );
+        assert!(sent.iter().any(|frame| {
+            let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+            comm_type == CommunicationType::ENABLE
+        }));
+    }
+
+    #[test]
+    fn csp_position_command_writes_limit_spd_and_loc_ref() {
+        let bus = Arc::new(MockBus::new());
+        let motor =
+            Arc::new(RobstrideMotor::new(2, 0xFD, "rs-00", bus.clone()).expect("create motor"));
+        let responder = spawn_enable_responder(Arc::clone(&motor), Arc::clone(&bus));
+
+        motor
+            .send_cmd_pos_vel_csp(-0.3, 0.04)
+            .expect("send CSP position command");
+        responder.join().expect("enable responder");
+
+        let sent = bus.sent.lock().expect("sent frames");
+        assert_eq!(
+            parameter_writes(&sent),
+            vec![
+                (ParameterId::Mode as u16, [5, 0, 0, 0]),
+                (ParameterId::VelocityLimit as u16, 0.04f32.to_le_bytes()),
+                (ParameterId::PositionTarget as u16, (-0.3f32).to_le_bytes()),
+            ]
+        );
+        assert!(sent.iter().any(|frame| {
+            let (comm_type, _, _) = ext_id_parts(frame.arbitration_id);
+            comm_type == CommunicationType::ENABLE
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `pos_vel_pp` / `pos-vel-pp` WebSocket operations for RobStride
- add `pos_vel_csp` / `pos-vel-csp` WebSocket operations for RobStride
- advertise `pos_vel_pp` and `pos_vel_csp` in RobStride capabilities only
- route PP through `vel_max` (`0x7024`), `acc_set` (`0x7025`), and `loc_ref` (`0x7016`)
- route CSP through `limit_spd` (`0x7017`) and `loc_ref` (`0x7016`)
- retain legacy RobStride `pos_vel` as an explicit PP compatibility alias, mapping `vlim` to `vel_max`
- reject `continuous=true` for PP with an actionable error; CSP remains the cyclic position path
- leave Damiao, Hexfellow, MyActuator, and HighTorque routing unchanged

## Root cause

The gateway selected RobStride PP (`run_mode=1`) for the unified `pos_vel` operation but wrote the requested speed to CSP's `0x7017 limit_spd`. The RobStride manual assigns PP speed and acceleration to `0x7024 vel_max` and `0x7025 acc_set`; `0x7017 limit_spd` applies to CSP (`run_mode=5`).

Reference:

https://wiki.aifitlab.com/robstride-docs/robstride-00-instruction-manual

## New operations

PP:

```json
{
  "op": "pos_vel_pp",
  "pos": 0.5,
  "vel_max": 0.02,
  "acc_set": 0.05
}
```

CSP:

```json
{
  "op": "pos_vel_csp",
  "pos": 0.5,
  "limit_spd": 0.02,
  "continuous": false
}
```

For transition compatibility, `vel_max` accepts `vlim` as an alias and `acc_set` accepts `acc`. The response uses the native parameter names.

## Compatibility

The existing RobStride `pos_vel` operation remains available and still selects PP (`run_mode=1`). Its `vlim` field now controls the PP parameter that matches that mode instead of CSP's `limit_spd`. The response identifies the native mode and includes a warning recommending the explicit PP operation.

Other vendors do not advertise or accept the RobStride-specific operations.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- protocol-level tests assert the exact PP and CSP parameter writes
- WebSocket routing tests cover underscore/hyphen aliases, native and compatibility field names, legacy `vlim -> vel_max`, and vendor capabilities

On Windows the commands were run with the installed stable GNU-host toolchain (`+stable-x86_64-pc-windows-gnu`) because MSVC Build Tools were not present.

## Hardware validation

Validated on Windows with MotorBridge 0.5.0, a Seeed reBot B601-RS, RobStride J1 (`motor_id=0x01`, host/master ID `0xFD`), and PCAN exposed as `can0`.

The explicit `pos_vel_pp` WebSocket operation moved J1 by exactly `0.020 rad` in each direction with `acc_set=0.05 rad/s²`:

| `vel_max` | Measured time |
| --- | ---: |
| `0.005 rad/s` | `4.02 s` |
| `0.020 rad/s` | `1.41 s` |

The slower move took `2.85x` as long, confirming that the PP path now applies `vel_max`. The gateway also advertised both `pos_vel_pp` and `pos_vel_csp` in the live RobStride capability response.

Only J1 was moved, with a maximum displacement of `0.020 rad`. No IDs, zero offsets, calibration, persistent protocol, or stored parameters were changed.